### PR TITLE
[feat] REQ-ETC-01 다국어 언어 전환 즉시 반영

### DIFF
--- a/front/src/hooks/useTranslation.ts
+++ b/front/src/hooks/useTranslation.ts
@@ -1,19 +1,6 @@
-import { useState, useCallback } from 'react';
-import { t as translate, getLocale, setLocale as setI18nLocale } from '../i18n';
-import type { Locale } from '../utils/constants';
+import { useI18n } from "../i18n/I18nProvider";
 
+/** Shared locale + translations via React Context (updates all consumers without refresh). */
 export function useTranslation() {
-  const [locale, setLocaleState] = useState<Locale>(getLocale());
-
-  const setLocale = useCallback((newLocale: Locale) => {
-    setI18nLocale(newLocale);
-    setLocaleState(newLocale);
-  }, []);
-
-  const t = useCallback((key: string): string => {
-    return translate(key);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [locale]);
-
-  return { t, locale, setLocale };
+  return useI18n();
 }

--- a/front/src/i18n/I18nProvider.tsx
+++ b/front/src/i18n/I18nProvider.tsx
@@ -1,0 +1,57 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { STORAGE_KEYS } from "../utils/constants";
+import type { Locale } from "../utils/constants";
+import { setLocale as setModuleLocale, translate } from "./index";
+
+type I18nContextValue = {
+  locale: Locale;
+  setLocale: (locale: Locale) => void;
+  t: (key: string) => string;
+};
+
+const I18nContext = createContext<I18nContextValue | null>(null);
+
+function readStoredLocale(): Locale {
+  const raw = localStorage.getItem(STORAGE_KEYS.LOCALE);
+  if (raw === "ko" || raw === "ru" || raw === "en") return raw;
+  return "ko";
+}
+
+export function I18nProvider({ children }: { children: ReactNode }) {
+  const [locale, setLocaleState] = useState<Locale>(() => {
+    const initial = readStoredLocale();
+    setModuleLocale(initial);
+    return initial;
+  });
+
+  const setLocale = useCallback((newLocale: Locale) => {
+    setModuleLocale(newLocale);
+    setLocaleState(newLocale);
+  }, []);
+
+  const t = useCallback((key: string) => translate(key, locale), [locale]);
+
+  const value = useMemo(
+    () => ({ locale, setLocale, t }),
+    [locale, setLocale, t],
+  );
+
+  return (
+    <I18nContext.Provider value={value}>{children}</I18nContext.Provider>
+  );
+}
+
+export function useI18n(): I18nContextValue {
+  const ctx = useContext(I18nContext);
+  if (!ctx) {
+    throw new Error("useI18n must be used within I18nProvider");
+  }
+  return ctx;
+}

--- a/front/src/i18n/index.ts
+++ b/front/src/i18n/index.ts
@@ -19,6 +19,11 @@ export function setLocale(locale: Locale): void {
   localStorage.setItem(STORAGE_KEYS.LOCALE, locale);
 }
 
+/** Look up message for a specific locale (used by I18nProvider and tests). */
+export function translate(key: string, locale: Locale): string {
+  return messages[locale]?.[key] ?? key;
+}
+
 export function t(key: string): string {
-  return messages[currentLocale]?.[key] ?? key;
+  return translate(key, currentLocale);
 }

--- a/front/src/main.tsx
+++ b/front/src/main.tsx
@@ -1,11 +1,14 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { RouterProvider } from 'react-router'
+import { I18nProvider } from './i18n/I18nProvider'
 import { router } from './routes'
 import './styles/index.css'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <RouterProvider router={router} />
+    <I18nProvider>
+      <RouterProvider router={router} />
+    </I18nProvider>
   </StrictMode>,
 )

--- a/front/src/utils/format.test.ts
+++ b/front/src/utils/format.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from 'vitest';
 import { localeToTag, formatDate, formatNumber } from './format';
-import type { Locale } from './constants';
 
 describe('localeToTag', () => {
   it('returns ko-KR for ko', () => {


### PR DESCRIPTION
[feat] REQ-ETC-01 다국어 언어 전환 즉시 반영

변경 사항
다국어 언어 전환 즉시 반영


테스트

[O] 로컬에서 테스트 완료
[O] 관련 기능 수동 테스트 완료

체크리스트

[O] 컨벤션에 맞게 커밋/브랜치 이름 작성
[O] 불필요한 로그/주석 제거
[O] 문서(README/주석) 업데이트 필요 시 반영

관련 이슈/티켓

REQ-ETC-01