### PR TITLE
Feature/req 007 admin page

### DIFF
--- a/back/src/main/java/com/ruxpress/common/entity/BaseEntity.java
+++ b/back/src/main/java/com/ruxpress/common/entity/BaseEntity.java
@@ -26,4 +26,8 @@ public abstract class BaseEntity {
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
+
+    public void markDeleted() {
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/back/src/main/java/com/ruxpress/config/DataInitializer.java
+++ b/back/src/main/java/com/ruxpress/config/DataInitializer.java
@@ -1,0 +1,57 @@
+package com.ruxpress.config;
+
+import com.ruxpress.domain.admin.entity.Admin;
+import com.ruxpress.domain.admin.entity.AdminRole;
+import com.ruxpress.domain.admin.repository.AdminRepository;
+import com.ruxpress.domain.user.entity.SignupType;
+import com.ruxpress.domain.user.entity.User;
+import com.ruxpress.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@Profile("local")
+@RequiredArgsConstructor
+public class DataInitializer implements CommandLineRunner {
+
+    private final AdminRepository adminRepository;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public void run(String... args) {
+        if (adminRepository.count() == 0) {
+            Admin superAdmin = Admin.create(
+                    "admin@ruxpress.com",
+                    passwordEncoder.encode("admin1234"),
+                    "슈퍼관리자",
+                    "010-0000-0000",
+                    AdminRole.SUPER_ADMIN
+            );
+            adminRepository.save(superAdmin);
+
+            Admin counselor = Admin.create(
+                    "counselor@ruxpress.com",
+                    passwordEncoder.encode("counsel1234"),
+                    "상담사",
+                    "010-1111-1111",
+                    AdminRole.COUNSELOR
+            );
+            adminRepository.save(counselor);
+
+            log.info("Seed admins created: admin@ruxpress.com / admin1234, counselor@ruxpress.com / counsel1234");
+        }
+
+        if (userRepository.count() == 0) {
+            userRepository.save(User.create("user1@test.com", "테스트유저1", SignupType.EMAIL));
+            userRepository.save(User.create("user2@test.com", "테스트유저2", SignupType.EMAIL));
+            userRepository.save(User.create("user3@test.com", "구글유저", SignupType.GOOGLE));
+            log.info("Seed users created: user1@test.com, user2@test.com, user3@test.com");
+        }
+    }
+}

--- a/back/src/main/java/com/ruxpress/config/JwtAuthenticationFilter.java
+++ b/back/src/main/java/com/ruxpress/config/JwtAuthenticationFilter.java
@@ -1,0 +1,56 @@
+package com.ruxpress.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String token = resolveToken(request);
+
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            Long adminId = jwtTokenProvider.getAdminId(token);
+            String role = jwtTokenProvider.getRole(token);
+
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(
+                            adminId,
+                            null,
+                            List.of(new SimpleGrantedAuthority("ROLE_" + role))
+                    );
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+}

--- a/back/src/main/java/com/ruxpress/config/JwtProperties.java
+++ b/back/src/main/java/com/ruxpress/config/JwtProperties.java
@@ -1,0 +1,15 @@
+package com.ruxpress.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "app.jwt")
+public class JwtProperties {
+    private String secret;
+    private long expiration;
+}

--- a/back/src/main/java/com/ruxpress/config/JwtTokenProvider.java
+++ b/back/src/main/java/com/ruxpress/config/JwtTokenProvider.java
@@ -1,0 +1,72 @@
+package com.ruxpress.config;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private final JwtProperties jwtProperties;
+    private SecretKey key;
+
+    @PostConstruct
+    public void init() {
+        byte[] keyBytes = jwtProperties.getSecret().getBytes(StandardCharsets.UTF_8);
+        if (keyBytes.length < 32) {
+            byte[] padded = new byte[32];
+            System.arraycopy(keyBytes, 0, padded, 0, keyBytes.length);
+            keyBytes = padded;
+        }
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String createToken(Long adminId, String email, String role) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + jwtProperties.getExpiration());
+
+        return Jwts.builder()
+                .subject(String.valueOf(adminId))
+                .claim("email", email)
+                .claim("role", role)
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(key)
+                .compact();
+    }
+
+    public Long getAdminId(String token) {
+        return Long.parseLong(getClaims(token).getSubject());
+    }
+
+    public String getRole(String token) {
+        return getClaims(token).get("role", String.class);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            getClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            log.debug("Invalid JWT token: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    private Claims getClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/back/src/main/java/com/ruxpress/config/SecurityConfig.java
+++ b/back/src/main/java/com/ruxpress/config/SecurityConfig.java
@@ -1,7 +1,9 @@
 package com.ruxpress.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -10,10 +12,14 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -24,9 +30,20 @@ public class SecurityConfig {
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        // TODO: 인증 필요한 경로 설정
+                        .requestMatchers("/api/v1/admin/auth/**").permitAll()
+                        .requestMatchers("/api/v1/admin/admins/**").hasRole("SUPER_ADMIN")
+                        .requestMatchers("/api/v1/admin/users/**").hasRole("SUPER_ADMIN")
+                        .requestMatchers("/api/v1/admin/notices/**").hasRole("SUPER_ADMIN")
+                        .requestMatchers("/api/v1/admin/settings/**").hasRole("SUPER_ADMIN")
+                        .requestMatchers("/api/v1/admin/inquiries/**").hasAnyRole("SUPER_ADMIN", "COUNSELOR")
+                        .requestMatchers("/api/v1/admin/reply-templates/**").hasAnyRole("SUPER_ADMIN", "COUNSELOR")
+                        .requestMatchers("/api/v1/admin/stats/**").hasAnyRole("SUPER_ADMIN", "COUNSELOR")
+                        .requestMatchers("/api/v1/admin/**").hasAnyRole("SUPER_ADMIN", "COUNSELOR")
+                        .requestMatchers(HttpMethod.GET, "/api/v1/notices/**").permitAll()
+                        .requestMatchers("/h2-console/**").permitAll()
                         .anyRequest().permitAll()
-                );
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/back/src/main/java/com/ruxpress/domain/admin/controller/AdminManagementController.java
+++ b/back/src/main/java/com/ruxpress/domain/admin/controller/AdminManagementController.java
@@ -1,0 +1,47 @@
+package com.ruxpress.domain.admin.controller;
+
+import com.ruxpress.common.dto.ApiResponse;
+import com.ruxpress.domain.admin.dto.request.AdminCreateRequest;
+import com.ruxpress.domain.admin.dto.request.AdminStatusChangeRequest;
+import com.ruxpress.domain.admin.dto.request.AdminUpdateRequest;
+import com.ruxpress.domain.admin.dto.response.AdminResponse;
+import com.ruxpress.domain.admin.service.AdminService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/admin/admins")
+@RequiredArgsConstructor
+public class AdminManagementController {
+
+    private final AdminService adminService;
+
+    @GetMapping
+    public ApiResponse<List<AdminResponse>> listAdmins() {
+        return ApiResponse.success(adminService.getAllAdmins());
+    }
+
+    @PostMapping
+    public ApiResponse<AdminResponse> createAdmin(@Valid @RequestBody AdminCreateRequest request) {
+        return ApiResponse.success(adminService.createAdmin(
+                request.getEmail(), request.getPassword(),
+                request.getName(), request.getPhone(), request.getRole()));
+    }
+
+    @PutMapping("/{id}")
+    public ApiResponse<AdminResponse> updateAdmin(
+            @PathVariable Long id,
+            @Valid @RequestBody AdminUpdateRequest request) {
+        return ApiResponse.success(adminService.updateAdmin(id, request.getName(), request.getPhone()));
+    }
+
+    @PatchMapping("/{id}/status")
+    public ApiResponse<AdminResponse> changeStatus(
+            @PathVariable Long id,
+            @Valid @RequestBody AdminStatusChangeRequest request) {
+        return ApiResponse.success(adminService.changeAdminStatus(id, request.getStatus()));
+    }
+}

--- a/back/src/main/java/com/ruxpress/domain/admin/controller/AdminSettingsController.java
+++ b/back/src/main/java/com/ruxpress/domain/admin/controller/AdminSettingsController.java
@@ -1,0 +1,47 @@
+package com.ruxpress.domain.admin.controller;
+
+import com.ruxpress.common.dto.ApiResponse;
+import com.ruxpress.domain.admin.dto.request.SettingUpdateRequest;
+import com.ruxpress.domain.admin.dto.response.SettingResponse;
+import com.ruxpress.domain.admin.entity.SystemSetting;
+import com.ruxpress.domain.admin.repository.SystemSettingRepository;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/admin/settings")
+@RequiredArgsConstructor
+public class AdminSettingsController {
+
+    private static final String FEE_RATE_KEY = "fee_rate";
+    private static final String DEFAULT_FEE_RATE = "12";
+
+    private final SystemSettingRepository repository;
+
+    @GetMapping("/fee-rate")
+    public ApiResponse<SettingResponse> getFeeRate() {
+        SystemSetting setting = repository.findById(FEE_RATE_KEY).orElse(null);
+        if (setting == null) {
+            return ApiResponse.success(new SettingResponse(FEE_RATE_KEY, DEFAULT_FEE_RATE, null, null));
+        }
+        return ApiResponse.success(new SettingResponse(
+                setting.getSettingKey(), setting.getSettingValue(),
+                setting.getUpdatedBy(), setting.getUpdatedAt()));
+    }
+
+    @PutMapping("/fee-rate")
+    public ApiResponse<SettingResponse> updateFeeRate(
+            Authentication auth,
+            @Valid @RequestBody SettingUpdateRequest request) {
+        Long adminId = auth != null ? (Long) auth.getPrincipal() : 1L;
+        SystemSetting setting = repository.findById(FEE_RATE_KEY)
+                .orElseGet(() -> SystemSetting.create(FEE_RATE_KEY, request.getValue(), adminId));
+        setting.updateValue(request.getValue(), adminId);
+        repository.save(setting);
+        return ApiResponse.success(new SettingResponse(
+                setting.getSettingKey(), setting.getSettingValue(),
+                setting.getUpdatedBy(), setting.getUpdatedAt()));
+    }
+}

--- a/back/src/main/java/com/ruxpress/domain/admin/controller/AdminStatsController.java
+++ b/back/src/main/java/com/ruxpress/domain/admin/controller/AdminStatsController.java
@@ -1,0 +1,45 @@
+package com.ruxpress.domain.admin.controller;
+
+import com.ruxpress.common.dto.ApiResponse;
+import com.ruxpress.domain.admin.dto.response.DashboardStatsResponse;
+import com.ruxpress.domain.inquiry.entity.InquiryStatus;
+import com.ruxpress.domain.inquiry.repository.InquiryRepository;
+import com.ruxpress.domain.notice.repository.NoticeRepository;
+import com.ruxpress.domain.user.entity.UserStatus;
+import com.ruxpress.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+@RestController
+@RequestMapping("/api/v1/admin/stats")
+@RequiredArgsConstructor
+public class AdminStatsController {
+
+    private final UserRepository userRepository;
+    private final InquiryRepository inquiryRepository;
+    private final NoticeRepository noticeRepository;
+
+    @GetMapping("/dashboard")
+    public ApiResponse<DashboardStatsResponse> dashboard() {
+        long totalUsers = userRepository.countByDeletedAtIsNull();
+        long newUsersToday = userRepository.countByCreatedAtAfterAndDeletedAtIsNull(
+                LocalDate.now().atStartOfDay());
+        long totalInquiries = inquiryRepository.countByDeletedAtIsNull();
+        long pendingInquiries = inquiryRepository.countByStatusAndDeletedAtIsNull(InquiryStatus.PENDING);
+        long totalNotices = noticeRepository.countByDeletedAtIsNull();
+
+        DashboardStatsResponse stats = DashboardStatsResponse.builder()
+                .totalUsers(totalUsers)
+                .newUsersToday(newUsersToday)
+                .totalInquiries(totalInquiries)
+                .pendingInquiries(pendingInquiries)
+                .totalNotices(totalNotices)
+                .build();
+
+        return ApiResponse.success(stats);
+    }
+}

--- a/back/src/main/java/com/ruxpress/domain/admin/controller/AuthController.java
+++ b/back/src/main/java/com/ruxpress/domain/admin/controller/AuthController.java
@@ -1,0 +1,26 @@
+package com.ruxpress.domain.admin.controller;
+
+import com.ruxpress.common.dto.ApiResponse;
+import com.ruxpress.domain.admin.dto.request.AdminLoginRequest;
+import com.ruxpress.domain.admin.dto.response.AdminLoginResponse;
+import com.ruxpress.domain.admin.service.AdminService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/admin/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AdminService adminService;
+
+    @PostMapping("/login")
+    public ApiResponse<AdminLoginResponse> login(@Valid @RequestBody AdminLoginRequest request) {
+        AdminLoginResponse response = adminService.login(request);
+        return ApiResponse.success(response);
+    }
+}

--- a/back/src/main/java/com/ruxpress/domain/admin/dto/request/AdminCreateRequest.java
+++ b/back/src/main/java/com/ruxpress/domain/admin/dto/request/AdminCreateRequest.java
@@ -1,0 +1,32 @@
+package com.ruxpress.domain.admin.dto.request;
+
+import com.ruxpress.domain.admin.entity.AdminRole;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminCreateRequest {
+
+    @NotBlank(message = "이메일을 입력해주세요")
+    @Email(message = "유효한 이메일 형식이 아닙니다")
+    private String email;
+
+    @NotBlank(message = "비밀번호를 입력해주세요")
+    @Size(min = 6, max = 100, message = "비밀번호는 6자 이상이어야 합니다")
+    private String password;
+
+    @NotBlank(message = "이름을 입력해주세요")
+    private String name;
+
+    private String phone;
+
+    @NotNull(message = "역할을 선택해주세요")
+    private AdminRole role;
+}

--- a/back/src/main/java/com/ruxpress/domain/admin/dto/request/AdminLoginRequest.java
+++ b/back/src/main/java/com/ruxpress/domain/admin/dto/request/AdminLoginRequest.java
@@ -1,0 +1,20 @@
+package com.ruxpress.domain.admin.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminLoginRequest {
+
+    @NotBlank(message = "이메일을 입력해주세요")
+    @Email(message = "유효한 이메일 형식이 아닙니다")
+    private String email;
+
+    @NotBlank(message = "비밀번호를 입력해주세요")
+    private String password;
+}

--- a/back/src/main/java/com/ruxpress/domain/admin/dto/request/AdminStatusChangeRequest.java
+++ b/back/src/main/java/com/ruxpress/domain/admin/dto/request/AdminStatusChangeRequest.java
@@ -1,0 +1,16 @@
+package com.ruxpress.domain.admin.dto.request;
+
+import com.ruxpress.domain.admin.entity.AdminStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminStatusChangeRequest {
+
+    @NotNull(message = "상태를 선택해주세요")
+    private AdminStatus status;
+}

--- a/back/src/main/java/com/ruxpress/domain/admin/dto/request/AdminUpdateRequest.java
+++ b/back/src/main/java/com/ruxpress/domain/admin/dto/request/AdminUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.ruxpress.domain.admin.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminUpdateRequest {
+
+    @NotBlank(message = "이름을 입력해주세요")
+    private String name;
+
+    private String phone;
+}

--- a/back/src/main/java/com/ruxpress/domain/admin/dto/request/SettingUpdateRequest.java
+++ b/back/src/main/java/com/ruxpress/domain/admin/dto/request/SettingUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.ruxpress.domain.admin.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SettingUpdateRequest {
+
+    @NotBlank(message = "값을 입력해주세요")
+    private String value;
+}

--- a/back/src/main/java/com/ruxpress/domain/admin/dto/response/AdminLoginResponse.java
+++ b/back/src/main/java/com/ruxpress/domain/admin/dto/response/AdminLoginResponse.java
@@ -1,0 +1,16 @@
+package com.ruxpress.domain.admin.dto.response;
+
+import com.ruxpress.domain.admin.entity.AdminRole;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AdminLoginResponse {
+
+    private final String token;
+    private final Long adminId;
+    private final String email;
+    private final String name;
+    private final AdminRole role;
+}

--- a/back/src/main/java/com/ruxpress/domain/admin/dto/response/AdminResponse.java
+++ b/back/src/main/java/com/ruxpress/domain/admin/dto/response/AdminResponse.java
@@ -1,0 +1,36 @@
+package com.ruxpress.domain.admin.dto.response;
+
+import com.ruxpress.domain.admin.entity.Admin;
+import com.ruxpress.domain.admin.entity.AdminRole;
+import com.ruxpress.domain.admin.entity.AdminStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class AdminResponse {
+
+    private final Long id;
+    private final String email;
+    private final String name;
+    private final String phone;
+    private final AdminRole role;
+    private final AdminStatus status;
+    private final LocalDateTime lastLoginAt;
+    private final LocalDateTime createdAt;
+
+    public static AdminResponse from(Admin admin) {
+        return new AdminResponse(
+                admin.getId(),
+                admin.getEmail(),
+                admin.getName(),
+                admin.getPhone(),
+                admin.getRole(),
+                admin.getStatus(),
+                admin.getLastLoginAt(),
+                admin.getCreatedAt()
+        );
+    }
+}

--- a/back/src/main/java/com/ruxpress/domain/admin/dto/response/DashboardStatsResponse.java
+++ b/back/src/main/java/com/ruxpress/domain/admin/dto/response/DashboardStatsResponse.java
@@ -1,0 +1,17 @@
+package com.ruxpress.domain.admin.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class DashboardStatsResponse {
+
+    private final long totalUsers;
+    private final long newUsersToday;
+    private final long totalInquiries;
+    private final long pendingInquiries;
+    private final long totalNotices;
+}

--- a/back/src/main/java/com/ruxpress/domain/admin/dto/response/SettingResponse.java
+++ b/back/src/main/java/com/ruxpress/domain/admin/dto/response/SettingResponse.java
@@ -1,0 +1,16 @@
+package com.ruxpress.domain.admin.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class SettingResponse {
+
+    private final String key;
+    private final String value;
+    private final Long updatedBy;
+    private final LocalDateTime updatedAt;
+}

--- a/back/src/main/java/com/ruxpress/domain/admin/entity/Admin.java
+++ b/back/src/main/java/com/ruxpress/domain/admin/entity/Admin.java
@@ -1,0 +1,71 @@
+package com.ruxpress.domain.admin.entity;
+
+import com.ruxpress.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "admins")
+public class Admin extends BaseEntity {
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Column(length = 20)
+    private String phone;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AdminRole role;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AdminStatus status = AdminStatus.ACTIVE;
+
+    @Column(name = "last_login_at")
+    private LocalDateTime lastLoginAt;
+
+    public static Admin create(String email, String encodedPassword, String name, String phone, AdminRole role) {
+        Admin admin = new Admin();
+        admin.email = email;
+        admin.password = encodedPassword;
+        admin.name = name;
+        admin.phone = phone;
+        admin.role = role;
+        admin.status = AdminStatus.ACTIVE;
+        return admin;
+    }
+
+    public void updateLastLogin() {
+        this.lastLoginAt = LocalDateTime.now();
+    }
+
+    public void updateInfo(String name, String phone) {
+        this.name = name;
+        if (phone != null) this.phone = phone;
+    }
+
+    public void changeStatus(AdminStatus status) {
+        this.status = status;
+    }
+
+    public void changeRole(AdminRole role) {
+        this.role = role;
+    }
+
+    public void changePassword(String encodedPassword) {
+        this.password = encodedPassword;
+    }
+}

--- a/back/src/main/java/com/ruxpress/domain/admin/entity/AdminRole.java
+++ b/back/src/main/java/com/ruxpress/domain/admin/entity/AdminRole.java
@@ -1,0 +1,6 @@
+package com.ruxpress.domain.admin.entity;
+
+public enum AdminRole {
+    SUPER_ADMIN,
+    COUNSELOR
+}

--- a/back/src/main/java/com/ruxpress/domain/admin/entity/AdminStatus.java
+++ b/back/src/main/java/com/ruxpress/domain/admin/entity/AdminStatus.java
@@ -1,0 +1,6 @@
+package com.ruxpress.domain.admin.entity;
+
+public enum AdminStatus {
+    ACTIVE,
+    INACTIVE
+}

--- a/back/src/main/java/com/ruxpress/domain/admin/entity/SystemSetting.java
+++ b/back/src/main/java/com/ruxpress/domain/admin/entity/SystemSetting.java
@@ -1,0 +1,45 @@
+package com.ruxpress.domain.admin.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "system_settings")
+@EntityListeners(AuditingEntityListener.class)
+public class SystemSetting {
+
+    @Id
+    @Column(name = "setting_key", length = 100)
+    private String settingKey;
+
+    @Column(name = "setting_value", nullable = false, length = 500)
+    private String settingValue;
+
+    @Column(name = "updated_by")
+    private Long updatedBy;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    public static SystemSetting create(String key, String value, Long updatedBy) {
+        SystemSetting s = new SystemSetting();
+        s.settingKey = key;
+        s.settingValue = value;
+        s.updatedBy = updatedBy;
+        return s;
+    }
+
+    public void updateValue(String value, Long updatedBy) {
+        this.settingValue = value;
+        this.updatedBy = updatedBy;
+    }
+}

--- a/back/src/main/java/com/ruxpress/domain/admin/repository/AdminRepository.java
+++ b/back/src/main/java/com/ruxpress/domain/admin/repository/AdminRepository.java
@@ -1,0 +1,16 @@
+package com.ruxpress.domain.admin.repository;
+
+import com.ruxpress.domain.admin.entity.Admin;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface AdminRepository extends JpaRepository<Admin, Long> {
+
+    Optional<Admin> findByEmailAndDeletedAtIsNull(String email);
+
+    List<Admin> findByDeletedAtIsNullOrderByCreatedAtDesc();
+
+    boolean existsByEmailAndDeletedAtIsNull(String email);
+}

--- a/back/src/main/java/com/ruxpress/domain/admin/repository/SystemSettingRepository.java
+++ b/back/src/main/java/com/ruxpress/domain/admin/repository/SystemSettingRepository.java
@@ -1,0 +1,7 @@
+package com.ruxpress.domain.admin.repository;
+
+import com.ruxpress.domain.admin.entity.SystemSetting;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SystemSettingRepository extends JpaRepository<SystemSetting, String> {
+}

--- a/back/src/main/java/com/ruxpress/domain/admin/service/AdminService.java
+++ b/back/src/main/java/com/ruxpress/domain/admin/service/AdminService.java
@@ -1,10 +1,88 @@
 package com.ruxpress.domain.admin.service;
 
+import com.ruxpress.common.exception.BusinessException;
+import com.ruxpress.common.exception.ErrorCode;
+import com.ruxpress.config.JwtTokenProvider;
+import com.ruxpress.domain.admin.dto.request.AdminLoginRequest;
+import com.ruxpress.domain.admin.dto.response.AdminLoginResponse;
+import com.ruxpress.domain.admin.dto.response.AdminResponse;
+import com.ruxpress.domain.admin.entity.Admin;
+import com.ruxpress.domain.admin.entity.AdminRole;
+import com.ruxpress.domain.admin.entity.AdminStatus;
+import com.ruxpress.domain.admin.repository.AdminRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-// TODO: Admin 비즈니스 로직 구현
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class AdminService {
+
+    private final AdminRepository adminRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Transactional
+    public AdminLoginResponse login(AdminLoginRequest request) {
+        Admin admin = adminRepository.findByEmailAndDeletedAtIsNull(request.getEmail())
+                .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED));
+
+        if (admin.getStatus() != AdminStatus.ACTIVE) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+
+        if (!passwordEncoder.matches(request.getPassword(), admin.getPassword())) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
+
+        admin.updateLastLogin();
+        adminRepository.save(admin);
+
+        String token = jwtTokenProvider.createToken(admin.getId(), admin.getEmail(), admin.getRole().name());
+
+        return new AdminLoginResponse(
+                token,
+                admin.getId(),
+                admin.getEmail(),
+                admin.getName(),
+                admin.getRole()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public List<AdminResponse> getAllAdmins() {
+        return adminRepository.findByDeletedAtIsNullOrderByCreatedAtDesc()
+                .stream()
+                .map(AdminResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public AdminResponse createAdmin(String email, String password, String name, String phone, AdminRole role) {
+        if (adminRepository.existsByEmailAndDeletedAtIsNull(email)) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+        Admin admin = Admin.create(email, passwordEncoder.encode(password), name, phone, role);
+        return AdminResponse.from(adminRepository.save(admin));
+    }
+
+    @Transactional
+    public AdminResponse updateAdmin(Long id, String name, String phone) {
+        Admin admin = adminRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+        admin.updateInfo(name, phone);
+        return AdminResponse.from(adminRepository.save(admin));
+    }
+
+    @Transactional
+    public AdminResponse changeAdminStatus(Long id, AdminStatus status) {
+        Admin admin = adminRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+        admin.changeStatus(status);
+        return AdminResponse.from(adminRepository.save(admin));
+    }
 }

--- a/back/src/main/java/com/ruxpress/domain/inquiry/controller/AdminInquiryController.java
+++ b/back/src/main/java/com/ruxpress/domain/inquiry/controller/AdminInquiryController.java
@@ -1,0 +1,65 @@
+package com.ruxpress.domain.inquiry.controller;
+
+import com.ruxpress.common.dto.ApiResponse;
+import com.ruxpress.common.dto.PageResponse;
+import com.ruxpress.domain.inquiry.dto.request.InquiryReplyCreateRequest;
+import com.ruxpress.domain.inquiry.dto.request.InquiryStatusChangeRequest;
+import com.ruxpress.domain.inquiry.dto.response.AdminInquiryListResponse;
+import com.ruxpress.domain.inquiry.dto.response.InquiryResponse;
+import com.ruxpress.domain.inquiry.service.InquiryService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/admin/inquiries")
+@RequiredArgsConstructor
+public class AdminInquiryController {
+
+    private final InquiryService inquiryService;
+
+    @GetMapping
+    public ApiResponse<PageResponse<AdminInquiryListResponse>> listInquiries(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "50") int size) {
+        return ApiResponse.success(inquiryService.getAllInquiriesForAdmin(PageRequest.of(page, size)));
+    }
+
+    @GetMapping("/{id}")
+    public ApiResponse<InquiryResponse> getDetail(@PathVariable Long id) {
+        return ApiResponse.success(inquiryService.getInquiryDetailForAdmin(id));
+    }
+
+    @PostMapping("/{id}/replies")
+    public ApiResponse<InquiryResponse> addReply(
+            Authentication auth,
+            @PathVariable Long id,
+            @Valid @RequestBody InquiryReplyCreateRequest request) {
+        Long adminId = auth != null ? (Long) auth.getPrincipal() : 1L;
+        return ApiResponse.success(inquiryService.addAdminReply(adminId, id, request.getContent()));
+    }
+
+    @PutMapping("/{id}/replies/{replyId}")
+    public ApiResponse<InquiryResponse> updateReply(
+            @PathVariable Long id,
+            @PathVariable Long replyId,
+            @Valid @RequestBody InquiryReplyCreateRequest request) {
+        return ApiResponse.success(inquiryService.updateAdminReply(id, replyId, request.getContent()));
+    }
+
+    @DeleteMapping("/{id}/replies/{replyId}")
+    public ApiResponse<InquiryResponse> deleteReply(
+            @PathVariable Long id,
+            @PathVariable Long replyId) {
+        return ApiResponse.success(inquiryService.deleteAdminReply(id, replyId));
+    }
+
+    @PatchMapping("/{id}/status")
+    public ApiResponse<InquiryResponse> changeStatus(
+            @PathVariable Long id,
+            @Valid @RequestBody InquiryStatusChangeRequest request) {
+        return ApiResponse.success(inquiryService.changeInquiryStatus(id, request.getStatus()));
+    }
+}

--- a/back/src/main/java/com/ruxpress/domain/inquiry/controller/ReplyTemplateController.java
+++ b/back/src/main/java/com/ruxpress/domain/inquiry/controller/ReplyTemplateController.java
@@ -1,0 +1,51 @@
+package com.ruxpress.domain.inquiry.controller;
+
+import com.ruxpress.common.dto.ApiResponse;
+import com.ruxpress.common.exception.BusinessException;
+import com.ruxpress.common.exception.ErrorCode;
+import com.ruxpress.domain.inquiry.dto.request.ReplyTemplateRequest;
+import com.ruxpress.domain.inquiry.dto.response.ReplyTemplateResponse;
+import com.ruxpress.domain.inquiry.entity.ReplyTemplate;
+import com.ruxpress.domain.inquiry.repository.ReplyTemplateRepository;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/v1/admin/reply-templates")
+@RequiredArgsConstructor
+public class ReplyTemplateController {
+
+    private final ReplyTemplateRepository repository;
+
+    @GetMapping
+    public ApiResponse<List<ReplyTemplateResponse>> list() {
+        List<ReplyTemplateResponse> list = repository.findByDeletedAtIsNullOrderBySortOrderAscCreatedAtDesc()
+                .stream().map(ReplyTemplateResponse::from).collect(Collectors.toList());
+        return ApiResponse.success(list);
+    }
+
+    @PostMapping
+    public ApiResponse<ReplyTemplateResponse> create(@Valid @RequestBody ReplyTemplateRequest req) {
+        ReplyTemplate t = ReplyTemplate.create(req.getTitle(), req.getContent(), req.getCategory(), req.getSortOrder());
+        return ApiResponse.success(ReplyTemplateResponse.from(repository.save(t)));
+    }
+
+    @PutMapping("/{id}")
+    public ApiResponse<ReplyTemplateResponse> update(@PathVariable Long id, @Valid @RequestBody ReplyTemplateRequest req) {
+        ReplyTemplate t = repository.findById(id).orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+        t.update(req.getTitle(), req.getContent(), req.getCategory(), req.getSortOrder());
+        return ApiResponse.success(ReplyTemplateResponse.from(repository.save(t)));
+    }
+
+    @DeleteMapping("/{id}")
+    public ApiResponse<Void> delete(@PathVariable Long id) {
+        ReplyTemplate t = repository.findById(id).orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+        t.markDeleted();
+        repository.save(t);
+        return ApiResponse.success(null);
+    }
+}

--- a/back/src/main/java/com/ruxpress/domain/inquiry/dto/request/InquiryReplyCreateRequest.java
+++ b/back/src/main/java/com/ruxpress/domain/inquiry/dto/request/InquiryReplyCreateRequest.java
@@ -1,0 +1,17 @@
+package com.ruxpress.domain.inquiry.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class InquiryReplyCreateRequest {
+
+    @NotBlank(message = "답변 내용을 입력해주세요")
+    @Size(max = 10000)
+    private String content;
+}

--- a/back/src/main/java/com/ruxpress/domain/inquiry/dto/request/InquiryStatusChangeRequest.java
+++ b/back/src/main/java/com/ruxpress/domain/inquiry/dto/request/InquiryStatusChangeRequest.java
@@ -1,0 +1,16 @@
+package com.ruxpress.domain.inquiry.dto.request;
+
+import com.ruxpress.domain.inquiry.entity.InquiryStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class InquiryStatusChangeRequest {
+
+    @NotNull(message = "상태를 선택해주세요")
+    private InquiryStatus status;
+}

--- a/back/src/main/java/com/ruxpress/domain/inquiry/dto/request/ReplyTemplateRequest.java
+++ b/back/src/main/java/com/ruxpress/domain/inquiry/dto/request/ReplyTemplateRequest.java
@@ -1,0 +1,26 @@
+package com.ruxpress.domain.inquiry.dto.request;
+
+import com.ruxpress.domain.inquiry.entity.InquiryCategory;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReplyTemplateRequest {
+
+    @NotBlank(message = "템플릿 제목을 입력해주세요")
+    @Size(max = 200)
+    private String title;
+
+    @NotBlank(message = "템플릿 내용을 입력해주세요")
+    @Size(max = 10000)
+    private String content;
+
+    private InquiryCategory category;
+
+    private int sortOrder;
+}

--- a/back/src/main/java/com/ruxpress/domain/inquiry/dto/response/AdminInquiryListResponse.java
+++ b/back/src/main/java/com/ruxpress/domain/inquiry/dto/response/AdminInquiryListResponse.java
@@ -1,0 +1,22 @@
+package com.ruxpress.domain.inquiry.dto.response;
+
+import com.ruxpress.domain.inquiry.entity.InquiryCategory;
+import com.ruxpress.domain.inquiry.entity.InquiryStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class AdminInquiryListResponse {
+
+    private final Long id;
+    private final Long userId;
+    private final InquiryCategory category;
+    private final String title;
+    private final InquiryStatus status;
+    private final int replyCount;
+    private final boolean hasUnreadReply;
+    private final LocalDateTime createdAt;
+}

--- a/back/src/main/java/com/ruxpress/domain/inquiry/dto/response/ReplyTemplateResponse.java
+++ b/back/src/main/java/com/ruxpress/domain/inquiry/dto/response/ReplyTemplateResponse.java
@@ -1,0 +1,21 @@
+package com.ruxpress.domain.inquiry.dto.response;
+
+import com.ruxpress.domain.inquiry.entity.InquiryCategory;
+import com.ruxpress.domain.inquiry.entity.ReplyTemplate;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ReplyTemplateResponse {
+
+    private final Long id;
+    private final String title;
+    private final String content;
+    private final InquiryCategory category;
+    private final int sortOrder;
+
+    public static ReplyTemplateResponse from(ReplyTemplate t) {
+        return new ReplyTemplateResponse(t.getId(), t.getTitle(), t.getContent(), t.getCategory(), t.getSortOrder());
+    }
+}

--- a/back/src/main/java/com/ruxpress/domain/inquiry/entity/Inquiry.java
+++ b/back/src/main/java/com/ruxpress/domain/inquiry/entity/Inquiry.java
@@ -44,4 +44,14 @@ public class Inquiry extends BaseEntity {
         inquiry.status = InquiryStatus.PENDING;
         return inquiry;
     }
+
+    public void markAsReplied() {
+        if (this.status != InquiryStatus.CLOSED) {
+            this.status = InquiryStatus.REPLIED;
+        }
+    }
+
+    public void changeStatus(InquiryStatus newStatus) {
+        this.status = newStatus;
+    }
 }

--- a/back/src/main/java/com/ruxpress/domain/inquiry/entity/InquiryReply.java
+++ b/back/src/main/java/com/ruxpress/domain/inquiry/entity/InquiryReply.java
@@ -33,4 +33,9 @@ public class InquiryReply extends BaseEntity {
         reply.isRead = false;
         return reply;
     }
+
+    public void updateContent(String newContent) {
+        this.content = newContent;
+    }
+
 }

--- a/back/src/main/java/com/ruxpress/domain/inquiry/entity/ReplyTemplate.java
+++ b/back/src/main/java/com/ruxpress/domain/inquiry/entity/ReplyTemplate.java
@@ -1,0 +1,43 @@
+package com.ruxpress.domain.inquiry.entity;
+
+import com.ruxpress.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "reply_templates")
+public class ReplyTemplate extends BaseEntity {
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = true)
+    private InquiryCategory category;
+
+    @Column(name = "sort_order", nullable = false)
+    private int sortOrder = 0;
+
+    public static ReplyTemplate create(String title, String content, InquiryCategory category, int sortOrder) {
+        ReplyTemplate t = new ReplyTemplate();
+        t.title = title;
+        t.content = content;
+        t.category = category;
+        t.sortOrder = sortOrder;
+        return t;
+    }
+
+    public void update(String title, String content, InquiryCategory category, int sortOrder) {
+        this.title = title;
+        this.content = content;
+        this.category = category;
+        this.sortOrder = sortOrder;
+    }
+}

--- a/back/src/main/java/com/ruxpress/domain/inquiry/repository/InquiryRepository.java
+++ b/back/src/main/java/com/ruxpress/domain/inquiry/repository/InquiryRepository.java
@@ -8,4 +8,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
 
     Page<Inquiry> findByUserIdAndDeletedAtIsNullOrderByCreatedAtDesc(Long userId, Pageable pageable);
+
+    Page<Inquiry> findByDeletedAtIsNullOrderByCreatedAtDesc(Pageable pageable);
+
+    long countByDeletedAtIsNull();
+
+    long countByStatusAndDeletedAtIsNull(com.ruxpress.domain.inquiry.entity.InquiryStatus status);
 }

--- a/back/src/main/java/com/ruxpress/domain/inquiry/repository/ReplyTemplateRepository.java
+++ b/back/src/main/java/com/ruxpress/domain/inquiry/repository/ReplyTemplateRepository.java
@@ -1,0 +1,11 @@
+package com.ruxpress.domain.inquiry.repository;
+
+import com.ruxpress.domain.inquiry.entity.ReplyTemplate;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ReplyTemplateRepository extends JpaRepository<ReplyTemplate, Long> {
+
+    List<ReplyTemplate> findByDeletedAtIsNullOrderBySortOrderAscCreatedAtDesc();
+}

--- a/back/src/main/java/com/ruxpress/domain/inquiry/service/InquiryService.java
+++ b/back/src/main/java/com/ruxpress/domain/inquiry/service/InquiryService.java
@@ -9,11 +9,13 @@ import com.ruxpress.common.storage.FileStoragePort;
 import com.ruxpress.common.dto.AttachmentResponse;
 import com.ruxpress.common.dto.PageResponse;
 import com.ruxpress.domain.inquiry.dto.request.InquiryCreateRequest;
+import com.ruxpress.domain.inquiry.dto.response.AdminInquiryListResponse;
 import com.ruxpress.domain.inquiry.dto.response.InquiryListResponse;
 import com.ruxpress.domain.inquiry.dto.response.InquiryReplyResponse;
 import com.ruxpress.domain.inquiry.dto.response.InquiryResponse;
 import com.ruxpress.domain.inquiry.entity.Inquiry;
 import com.ruxpress.domain.inquiry.entity.InquiryReply;
+import com.ruxpress.domain.inquiry.entity.InquiryStatus;
 import com.ruxpress.domain.inquiry.repository.InquiryReplyRepository;
 import com.ruxpress.domain.inquiry.repository.InquiryRepository;
 import lombok.RequiredArgsConstructor;
@@ -128,6 +130,79 @@ public class InquiryService {
         Attachment attachment = attachmentRepository.findById(attachmentId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
         return attachment.getOriginalFilename();
+    }
+
+    // ─── Admin methods ────────────────────────────────────────────
+
+    @Transactional(readOnly = true)
+    public PageResponse<AdminInquiryListResponse> getAllInquiriesForAdmin(Pageable pageable) {
+        Page<Inquiry> page = inquiryRepository.findByDeletedAtIsNullOrderByCreatedAtDesc(pageable);
+        List<AdminInquiryListResponse> content = page.getContent().stream()
+                .map(this::toAdminListResponse)
+                .collect(Collectors.toList());
+        return new PageResponse<>(content, page.getTotalElements(), page.getTotalPages(), page.getNumber(), page.getSize());
+    }
+
+    @Transactional(readOnly = true)
+    public InquiryResponse getInquiryDetailForAdmin(Long inquiryId) {
+        Inquiry inquiry = inquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INQUIRY_NOT_FOUND));
+        return toDetailResponse(inquiry);
+    }
+
+    @Transactional
+    public InquiryResponse addAdminReply(Long adminId, Long inquiryId, String replyContent) {
+        Inquiry inquiry = inquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INQUIRY_NOT_FOUND));
+        if (inquiry.getStatus() == InquiryStatus.CLOSED) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+        InquiryReply reply = InquiryReply.create(inquiry, adminId, replyContent);
+        inquiryReplyRepository.save(reply);
+        inquiry.markAsReplied();
+        inquiryRepository.save(inquiry);
+        return toDetailResponse(inquiry);
+    }
+
+    @Transactional
+    public InquiryResponse updateAdminReply(Long inquiryId, Long replyId, String newContent) {
+        InquiryReply reply = inquiryReplyRepository.findById(replyId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+        if (!reply.getInquiry().getId().equals(inquiryId)) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+        reply.updateContent(newContent);
+        inquiryReplyRepository.save(reply);
+        return toDetailResponse(reply.getInquiry());
+    }
+
+    @Transactional
+    public InquiryResponse deleteAdminReply(Long inquiryId, Long replyId) {
+        InquiryReply reply = inquiryReplyRepository.findById(replyId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+        if (!reply.getInquiry().getId().equals(inquiryId)) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+        reply.markDeleted();
+        inquiryReplyRepository.save(reply);
+        return toDetailResponse(reply.getInquiry());
+    }
+
+    @Transactional
+    public InquiryResponse changeInquiryStatus(Long inquiryId, InquiryStatus newStatus) {
+        Inquiry inquiry = inquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INQUIRY_NOT_FOUND));
+        inquiry.changeStatus(newStatus);
+        inquiryRepository.save(inquiry);
+        return toDetailResponse(inquiry);
+    }
+
+    private AdminInquiryListResponse toAdminListResponse(Inquiry inquiry) {
+        List<InquiryReply> replies = inquiryReplyRepository.findByInquiry_IdAndDeletedAtIsNullOrderByCreatedAtAsc(inquiry.getId());
+        return new AdminInquiryListResponse(
+                inquiry.getId(), inquiry.getUserId(), inquiry.getCategory(), inquiry.getTitle(),
+                inquiry.getStatus(), replies.size(),
+                replies.stream().anyMatch(r -> !r.isRead()), inquiry.getCreatedAt());
     }
 
     private InquiryListResponse toListResponse(Inquiry inquiry) {

--- a/back/src/main/java/com/ruxpress/domain/notice/controller/AdminNoticeController.java
+++ b/back/src/main/java/com/ruxpress/domain/notice/controller/AdminNoticeController.java
@@ -1,0 +1,54 @@
+package com.ruxpress.domain.notice.controller;
+
+import com.ruxpress.common.dto.ApiResponse;
+import com.ruxpress.common.dto.PageResponse;
+import com.ruxpress.domain.notice.dto.request.NoticeCreateRequest;
+import com.ruxpress.domain.notice.dto.request.NoticeUpdateRequest;
+import com.ruxpress.domain.notice.dto.response.NoticeResponse;
+import com.ruxpress.domain.notice.service.NoticeService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/admin/notices")
+@RequiredArgsConstructor
+public class AdminNoticeController {
+
+    private final NoticeService noticeService;
+
+    @GetMapping
+    public ApiResponse<PageResponse<NoticeResponse>> list(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "50") int size) {
+        return ApiResponse.success(noticeService.getAllNoticesForAdmin(PageRequest.of(page, size)));
+    }
+
+    @PostMapping
+    public ApiResponse<NoticeResponse> create(
+            Authentication auth,
+            @Valid @RequestBody NoticeCreateRequest request) {
+        Long adminId = auth != null ? (Long) auth.getPrincipal() : 1L;
+        return ApiResponse.success(noticeService.createNotice(adminId, request));
+    }
+
+    @PutMapping("/{id}")
+    public ApiResponse<NoticeResponse> update(
+            @PathVariable Long id,
+            @Valid @RequestBody NoticeUpdateRequest request) {
+        return ApiResponse.success(noticeService.updateNotice(id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    public ApiResponse<Void> delete(@PathVariable Long id) {
+        noticeService.deleteNotice(id);
+        return ApiResponse.success(null);
+    }
+
+    @PatchMapping("/{id}/pin")
+    public ApiResponse<NoticeResponse> togglePin(@PathVariable Long id) {
+        return ApiResponse.success(noticeService.togglePin(id));
+    }
+}

--- a/back/src/main/java/com/ruxpress/domain/notice/controller/NoticeController.java
+++ b/back/src/main/java/com/ruxpress/domain/notice/controller/NoticeController.java
@@ -1,16 +1,29 @@
 package com.ruxpress.domain.notice.controller;
 
-import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
+import com.ruxpress.common.dto.ApiResponse;
+import com.ruxpress.common.dto.PageResponse;
+import com.ruxpress.domain.notice.dto.response.NoticeResponse;
 import com.ruxpress.domain.notice.service.NoticeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.web.bind.annotation.*;
 
-// TODO: Notice API 엔드포인트 구현
 @RestController
 @RequestMapping("/api/v1/notices")
 @RequiredArgsConstructor
 public class NoticeController {
 
     private final NoticeService noticeService;
+
+    @GetMapping
+    public ApiResponse<PageResponse<NoticeResponse>> listPublished(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        return ApiResponse.success(noticeService.getPublishedNotices(PageRequest.of(page, size)));
+    }
+
+    @GetMapping("/{id}")
+    public ApiResponse<NoticeResponse> getDetail(@PathVariable Long id) {
+        return ApiResponse.success(noticeService.getNoticeDetail(id));
+    }
 }

--- a/back/src/main/java/com/ruxpress/domain/notice/dto/request/NoticeCreateRequest.java
+++ b/back/src/main/java/com/ruxpress/domain/notice/dto/request/NoticeCreateRequest.java
@@ -1,0 +1,29 @@
+package com.ruxpress.domain.notice.dto.request;
+
+import com.ruxpress.domain.notice.entity.NoticeStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NoticeCreateRequest {
+
+    @NotBlank(message = "제목을 입력해주세요")
+    @Size(max = 300)
+    private String title;
+
+    @NotBlank(message = "내용을 입력해주세요")
+    private String content;
+
+    private boolean isPinned;
+
+    private NoticeStatus status;
+
+    private LocalDateTime scheduledAt;
+}

--- a/back/src/main/java/com/ruxpress/domain/notice/dto/request/NoticeUpdateRequest.java
+++ b/back/src/main/java/com/ruxpress/domain/notice/dto/request/NoticeUpdateRequest.java
@@ -1,0 +1,22 @@
+package com.ruxpress.domain.notice.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NoticeUpdateRequest {
+
+    @NotBlank(message = "제목을 입력해주세요")
+    @Size(max = 300)
+    private String title;
+
+    @NotBlank(message = "내용을 입력해주세요")
+    private String content;
+
+    private boolean isPinned;
+}

--- a/back/src/main/java/com/ruxpress/domain/notice/dto/response/NoticeResponse.java
+++ b/back/src/main/java/com/ruxpress/domain/notice/dto/response/NoticeResponse.java
@@ -1,0 +1,33 @@
+package com.ruxpress.domain.notice.dto.response;
+
+import com.ruxpress.domain.notice.entity.Notice;
+import com.ruxpress.domain.notice.entity.NoticeStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class NoticeResponse {
+
+    private final Long id;
+    private final Long adminId;
+    private final String title;
+    private final String content;
+    private final boolean isPinned;
+    private final int viewCount;
+    private final NoticeStatus status;
+    private final LocalDateTime publishedAt;
+    private final LocalDateTime scheduledAt;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public static NoticeResponse from(Notice n) {
+        return new NoticeResponse(
+                n.getId(), n.getAdminId(), n.getTitle(), n.getContent(),
+                n.isPinned(), n.getViewCount(), n.getStatus(),
+                n.getPublishedAt(), n.getScheduledAt(),
+                n.getCreatedAt(), n.getUpdatedAt());
+    }
+}

--- a/back/src/main/java/com/ruxpress/domain/notice/entity/Notice.java
+++ b/back/src/main/java/com/ruxpress/domain/notice/entity/Notice.java
@@ -1,0 +1,77 @@
+package com.ruxpress.domain.notice.entity;
+
+import com.ruxpress.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "notices")
+public class Notice extends BaseEntity {
+
+    @Column(name = "admin_id")
+    private Long adminId;
+
+    @Column(nullable = false, length = 300)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "is_pinned", nullable = false)
+    private boolean isPinned = false;
+
+    @Column(name = "view_count", nullable = false)
+    private int viewCount = 0;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NoticeStatus status = NoticeStatus.DRAFT;
+
+    @Column(name = "published_at")
+    private LocalDateTime publishedAt;
+
+    @Column(name = "scheduled_at")
+    private LocalDateTime scheduledAt;
+
+    public static Notice create(Long adminId, String title, String content, boolean isPinned,
+                                NoticeStatus status, LocalDateTime scheduledAt) {
+        Notice n = new Notice();
+        n.adminId = adminId;
+        n.title = title;
+        n.content = content;
+        n.isPinned = isPinned;
+        n.status = status;
+        if (status == NoticeStatus.PUBLISHED) {
+            n.publishedAt = LocalDateTime.now();
+        }
+        if (status == NoticeStatus.SCHEDULED) {
+            n.scheduledAt = scheduledAt;
+        }
+        return n;
+    }
+
+    public void update(String title, String content, boolean isPinned) {
+        this.title = title;
+        this.content = content;
+        this.isPinned = isPinned;
+    }
+
+    public void togglePin() {
+        this.isPinned = !this.isPinned;
+    }
+
+    public void publish() {
+        this.status = NoticeStatus.PUBLISHED;
+        this.publishedAt = LocalDateTime.now();
+    }
+
+    public void incrementViewCount() {
+        this.viewCount++;
+    }
+}

--- a/back/src/main/java/com/ruxpress/domain/notice/entity/NoticeStatus.java
+++ b/back/src/main/java/com/ruxpress/domain/notice/entity/NoticeStatus.java
@@ -1,0 +1,8 @@
+package com.ruxpress.domain.notice.entity;
+
+public enum NoticeStatus {
+    DRAFT,
+    SCHEDULED,
+    PUBLISHED,
+    HIDDEN
+}

--- a/back/src/main/java/com/ruxpress/domain/notice/repository/NoticeRepository.java
+++ b/back/src/main/java/com/ruxpress/domain/notice/repository/NoticeRepository.java
@@ -1,0 +1,23 @@
+package com.ruxpress.domain.notice.repository;
+
+import com.ruxpress.domain.notice.entity.Notice;
+import com.ruxpress.domain.notice.entity.NoticeStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+
+    Page<Notice> findByDeletedAtIsNullOrderByIsPinnedDescCreatedAtDesc(Pageable pageable);
+
+    Page<Notice> findByStatusAndDeletedAtIsNullOrderByIsPinnedDescPublishedAtDesc(
+            NoticeStatus status, Pageable pageable);
+
+    List<Notice> findByStatusAndScheduledAtBeforeAndDeletedAtIsNull(
+            NoticeStatus status, LocalDateTime now);
+
+    long countByDeletedAtIsNull();
+}

--- a/back/src/main/java/com/ruxpress/domain/notice/service/NoticeService.java
+++ b/back/src/main/java/com/ruxpress/domain/notice/service/NoticeService.java
@@ -1,10 +1,103 @@
 package com.ruxpress.domain.notice.service;
 
+import com.ruxpress.common.dto.PageResponse;
+import com.ruxpress.common.exception.BusinessException;
+import com.ruxpress.common.exception.ErrorCode;
+import com.ruxpress.domain.notice.dto.request.NoticeCreateRequest;
+import com.ruxpress.domain.notice.dto.request.NoticeUpdateRequest;
+import com.ruxpress.domain.notice.dto.response.NoticeResponse;
+import com.ruxpress.domain.notice.entity.Notice;
+import com.ruxpress.domain.notice.entity.NoticeStatus;
+import com.ruxpress.domain.notice.repository.NoticeRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-// TODO: Notice 비즈니스 로직 구현
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class NoticeService {
+
+    private final NoticeRepository noticeRepository;
+
+    // ─── Admin ────────────────────────────────────────────
+
+    @Transactional(readOnly = true)
+    public PageResponse<NoticeResponse> getAllNoticesForAdmin(Pageable pageable) {
+        Page<Notice> page = noticeRepository.findByDeletedAtIsNullOrderByIsPinnedDescCreatedAtDesc(pageable);
+        List<NoticeResponse> content = page.getContent().stream().map(NoticeResponse::from).collect(Collectors.toList());
+        return new PageResponse<>(content, page.getTotalElements(), page.getTotalPages(), page.getNumber(), page.getSize());
+    }
+
+    @Transactional
+    public NoticeResponse createNotice(Long adminId, NoticeCreateRequest request) {
+        NoticeStatus status = request.getStatus() != null ? request.getStatus() : NoticeStatus.PUBLISHED;
+        Notice notice = Notice.create(adminId, request.getTitle(), request.getContent(),
+                request.isPinned(), status, request.getScheduledAt());
+        return NoticeResponse.from(noticeRepository.save(notice));
+    }
+
+    @Transactional
+    public NoticeResponse updateNotice(Long noticeId, NoticeUpdateRequest request) {
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+        notice.update(request.getTitle(), request.getContent(), request.isPinned());
+        return NoticeResponse.from(noticeRepository.save(notice));
+    }
+
+    @Transactional
+    public void deleteNotice(Long noticeId) {
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+        notice.markDeleted();
+        noticeRepository.save(notice);
+    }
+
+    @Transactional
+    public NoticeResponse togglePin(Long noticeId) {
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+        notice.togglePin();
+        return NoticeResponse.from(noticeRepository.save(notice));
+    }
+
+    // ─── User-facing ──────────────────────────────────────
+
+    @Transactional(readOnly = true)
+    public PageResponse<NoticeResponse> getPublishedNotices(Pageable pageable) {
+        Page<Notice> page = noticeRepository.findByStatusAndDeletedAtIsNullOrderByIsPinnedDescPublishedAtDesc(
+                NoticeStatus.PUBLISHED, pageable);
+        List<NoticeResponse> content = page.getContent().stream().map(NoticeResponse::from).collect(Collectors.toList());
+        return new PageResponse<>(content, page.getTotalElements(), page.getTotalPages(), page.getNumber(), page.getSize());
+    }
+
+    @Transactional
+    public NoticeResponse getNoticeDetail(Long noticeId) {
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+        notice.incrementViewCount();
+        return NoticeResponse.from(noticeRepository.save(notice));
+    }
+
+    // ─── Scheduled publishing ─────────────────────────────
+
+    @Scheduled(fixedRate = 60000)
+    @Transactional
+    public void publishScheduledNotices() {
+        List<Notice> ready = noticeRepository.findByStatusAndScheduledAtBeforeAndDeletedAtIsNull(
+                NoticeStatus.SCHEDULED, LocalDateTime.now());
+        for (Notice notice : ready) {
+            notice.publish();
+            noticeRepository.save(notice);
+            log.info("Scheduled notice published: id={}, title={}", notice.getId(), notice.getTitle());
+        }
+    }
 }

--- a/back/src/main/java/com/ruxpress/domain/user/controller/AdminUserController.java
+++ b/back/src/main/java/com/ruxpress/domain/user/controller/AdminUserController.java
@@ -1,0 +1,48 @@
+package com.ruxpress.domain.user.controller;
+
+import com.ruxpress.common.dto.ApiResponse;
+import com.ruxpress.common.dto.PageResponse;
+import com.ruxpress.domain.user.dto.request.UserStatusChangeRequest;
+import com.ruxpress.domain.user.dto.response.UserResponse;
+import com.ruxpress.domain.user.dto.response.UserStatsResponse;
+import com.ruxpress.domain.user.entity.UserStatus;
+import com.ruxpress.domain.user.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/admin/users")
+@RequiredArgsConstructor
+public class AdminUserController {
+
+    private final UserService userService;
+
+    @GetMapping
+    public ApiResponse<PageResponse<UserResponse>> listUsers(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) UserStatus status,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        PageResponse<UserResponse> response = userService.getUsers(keyword, status, PageRequest.of(page, size));
+        return ApiResponse.success(response);
+    }
+
+    @GetMapping("/{id}")
+    public ApiResponse<UserResponse> getUserDetail(@PathVariable Long id) {
+        return ApiResponse.success(userService.getUserDetail(id));
+    }
+
+    @PatchMapping("/{id}/status")
+    public ApiResponse<UserResponse> changeUserStatus(
+            @PathVariable Long id,
+            @Valid @RequestBody UserStatusChangeRequest request) {
+        return ApiResponse.success(userService.changeUserStatus(id, request.getStatus()));
+    }
+
+    @GetMapping("/stats")
+    public ApiResponse<UserStatsResponse> getUserStats() {
+        return ApiResponse.success(userService.getUserStats());
+    }
+}

--- a/back/src/main/java/com/ruxpress/domain/user/dto/request/UserStatusChangeRequest.java
+++ b/back/src/main/java/com/ruxpress/domain/user/dto/request/UserStatusChangeRequest.java
@@ -1,0 +1,16 @@
+package com.ruxpress.domain.user.dto.request;
+
+import com.ruxpress.domain.user.entity.UserStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserStatusChangeRequest {
+
+    @NotNull(message = "상태를 선택해주세요")
+    private UserStatus status;
+}

--- a/back/src/main/java/com/ruxpress/domain/user/dto/response/UserResponse.java
+++ b/back/src/main/java/com/ruxpress/domain/user/dto/response/UserResponse.java
@@ -1,0 +1,48 @@
+package com.ruxpress.domain.user.dto.response;
+
+import com.ruxpress.domain.user.entity.SignupType;
+import com.ruxpress.domain.user.entity.User;
+import com.ruxpress.domain.user.entity.UserStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class UserResponse {
+
+    private final Long id;
+    private final String email;
+    private final String phone;
+    private final String nickname;
+    private final String profileImageUrl;
+    private final UserStatus status;
+    private final boolean emailVerified;
+    private final boolean phoneVerified;
+    private final SignupType signupType;
+    private final String timezone;
+    private final LocalDateTime lastLoginAt;
+    private final LocalDateTime withdrawnAt;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public static UserResponse from(User user) {
+        return new UserResponse(
+                user.getId(),
+                user.getEmail(),
+                user.getPhone(),
+                user.getNickname(),
+                user.getProfileImageUrl(),
+                user.getStatus(),
+                user.isEmailVerified(),
+                user.isPhoneVerified(),
+                user.getSignupType(),
+                user.getTimezone(),
+                user.getLastLoginAt(),
+                user.getWithdrawnAt(),
+                user.getCreatedAt(),
+                user.getUpdatedAt()
+        );
+    }
+}

--- a/back/src/main/java/com/ruxpress/domain/user/dto/response/UserStatsResponse.java
+++ b/back/src/main/java/com/ruxpress/domain/user/dto/response/UserStatsResponse.java
@@ -1,0 +1,15 @@
+package com.ruxpress.domain.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserStatsResponse {
+
+    private final long totalUsers;
+    private final long activeUsers;
+    private final long suspendedUsers;
+    private final long withdrawnUsers;
+    private final long newUsersToday;
+}

--- a/back/src/main/java/com/ruxpress/domain/user/entity/SignupType.java
+++ b/back/src/main/java/com/ruxpress/domain/user/entity/SignupType.java
@@ -1,0 +1,7 @@
+package com.ruxpress.domain.user.entity;
+
+public enum SignupType {
+    EMAIL,
+    PHONE,
+    GOOGLE
+}

--- a/back/src/main/java/com/ruxpress/domain/user/entity/User.java
+++ b/back/src/main/java/com/ruxpress/domain/user/entity/User.java
@@ -1,0 +1,71 @@
+package com.ruxpress.domain.user.entity;
+
+import com.ruxpress.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "users")
+public class User extends BaseEntity {
+
+    @Column(unique = true, length = 100)
+    private String email;
+
+    @Column(length = 20)
+    private String phone;
+
+    @Column(nullable = false, length = 50)
+    private String nickname;
+
+    @Column(name = "profile_image_url", length = 500)
+    private String profileImageUrl;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserStatus status = UserStatus.ACTIVE;
+
+    @Column(name = "email_verified", nullable = false)
+    private boolean emailVerified = false;
+
+    @Column(name = "phone_verified", nullable = false)
+    private boolean phoneVerified = false;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "signup_type", nullable = false)
+    private SignupType signupType;
+
+    @Column(length = 50)
+    private String timezone;
+
+    @Column(name = "last_login_at")
+    private LocalDateTime lastLoginAt;
+
+    @Column(name = "withdrawn_at")
+    private LocalDateTime withdrawnAt;
+
+    public static User create(String email, String nickname, SignupType signupType) {
+        User user = new User();
+        user.email = email;
+        user.nickname = nickname;
+        user.signupType = signupType;
+        user.status = UserStatus.ACTIVE;
+        return user;
+    }
+
+    public void changeStatus(UserStatus newStatus) {
+        this.status = newStatus;
+        if (newStatus == UserStatus.WITHDRAWN) {
+            this.withdrawnAt = LocalDateTime.now();
+        }
+    }
+
+    public void updateLastLogin() {
+        this.lastLoginAt = LocalDateTime.now();
+    }
+}

--- a/back/src/main/java/com/ruxpress/domain/user/entity/UserStatus.java
+++ b/back/src/main/java/com/ruxpress/domain/user/entity/UserStatus.java
@@ -1,0 +1,7 @@
+package com.ruxpress.domain.user.entity;
+
+public enum UserStatus {
+    ACTIVE,
+    SUSPENDED,
+    WITHDRAWN
+}

--- a/back/src/main/java/com/ruxpress/domain/user/repository/UserRepository.java
+++ b/back/src/main/java/com/ruxpress/domain/user/repository/UserRepository.java
@@ -1,0 +1,37 @@
+package com.ruxpress.domain.user.repository;
+
+import com.ruxpress.domain.user.entity.User;
+import com.ruxpress.domain.user.entity.UserStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Page<User> findByDeletedAtIsNullOrderByCreatedAtDesc(Pageable pageable);
+
+    Page<User> findByStatusAndDeletedAtIsNullOrderByCreatedAtDesc(UserStatus status, Pageable pageable);
+
+    @Query("SELECT u FROM User u WHERE u.deletedAt IS NULL " +
+           "AND (LOWER(u.email) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+           "  OR LOWER(u.nickname) LIKE LOWER(CONCAT('%', :keyword, '%'))) " +
+           "ORDER BY u.createdAt DESC")
+    Page<User> searchByKeyword(@Param("keyword") String keyword, Pageable pageable);
+
+    @Query("SELECT u FROM User u WHERE u.deletedAt IS NULL " +
+           "AND u.status = :status " +
+           "AND (LOWER(u.email) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+           "  OR LOWER(u.nickname) LIKE LOWER(CONCAT('%', :keyword, '%'))) " +
+           "ORDER BY u.createdAt DESC")
+    Page<User> searchByKeywordAndStatus(@Param("keyword") String keyword, @Param("status") UserStatus status, Pageable pageable);
+
+    long countByDeletedAtIsNull();
+
+    long countByStatusAndDeletedAtIsNull(UserStatus status);
+
+    long countByCreatedAtAfterAndDeletedAtIsNull(LocalDateTime after);
+}

--- a/back/src/main/java/com/ruxpress/domain/user/service/UserService.java
+++ b/back/src/main/java/com/ruxpress/domain/user/service/UserService.java
@@ -1,10 +1,79 @@
 package com.ruxpress.domain.user.service;
 
+import com.ruxpress.common.dto.PageResponse;
+import com.ruxpress.common.exception.BusinessException;
+import com.ruxpress.common.exception.ErrorCode;
+import com.ruxpress.domain.user.dto.response.UserResponse;
+import com.ruxpress.domain.user.dto.response.UserStatsResponse;
+import com.ruxpress.domain.user.entity.User;
+import com.ruxpress.domain.user.entity.UserStatus;
+import com.ruxpress.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-// TODO: User 비즈니스 로직 구현
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public PageResponse<UserResponse> getUsers(String keyword, UserStatus status, Pageable pageable) {
+        Page<User> page;
+
+        boolean hasKeyword = keyword != null && !keyword.isBlank();
+        boolean hasStatus = status != null;
+
+        if (hasKeyword && hasStatus) {
+            page = userRepository.searchByKeywordAndStatus(keyword.trim(), status, pageable);
+        } else if (hasKeyword) {
+            page = userRepository.searchByKeyword(keyword.trim(), pageable);
+        } else if (hasStatus) {
+            page = userRepository.findByStatusAndDeletedAtIsNullOrderByCreatedAtDesc(status, pageable);
+        } else {
+            page = userRepository.findByDeletedAtIsNullOrderByCreatedAtDesc(pageable);
+        }
+
+        List<UserResponse> content = page.getContent().stream()
+                .map(UserResponse::from)
+                .collect(Collectors.toList());
+
+        return new PageResponse<>(content, page.getTotalElements(), page.getTotalPages(), page.getNumber(), page.getSize());
+    }
+
+    @Transactional(readOnly = true)
+    public UserResponse getUserDetail(Long id) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+        return UserResponse.from(user);
+    }
+
+    @Transactional
+    public UserResponse changeUserStatus(Long id, UserStatus newStatus) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+        user.changeStatus(newStatus);
+        return UserResponse.from(userRepository.save(user));
+    }
+
+    @Transactional(readOnly = true)
+    public UserStatsResponse getUserStats() {
+        long total = userRepository.countByDeletedAtIsNull();
+        long active = userRepository.countByStatusAndDeletedAtIsNull(UserStatus.ACTIVE);
+        long suspended = userRepository.countByStatusAndDeletedAtIsNull(UserStatus.SUSPENDED);
+        long withdrawn = userRepository.countByStatusAndDeletedAtIsNull(UserStatus.WITHDRAWN);
+
+        LocalDateTime todayStart = LocalDate.now().atStartOfDay();
+        long newToday = userRepository.countByCreatedAtAfterAndDeletedAtIsNull(todayStart);
+
+        return new UserStatsResponse(total, active, suspended, withdrawn, newToday);
+    }
 }

--- a/front/src/components/layouts/AdminLayout.tsx
+++ b/front/src/components/layouts/AdminLayout.tsx
@@ -1,4 +1,4 @@
-import { Outlet, Link, useLocation, Navigate } from "react-router";
+import { Outlet, Link, useLocation, Navigate, useNavigate } from "react-router";
 import {
   LayoutDashboard,
   ShoppingCart,
@@ -8,35 +8,56 @@ import {
   Users,
   LogOut,
   Menu,
+  Shield,
 } from "lucide-react";
 import { Button } from "../ui/button";
 import { Sidebar, SidebarContent, SidebarHeader, SidebarMenu, SidebarMenuItem, SidebarMenuButton, SidebarProvider, SidebarTrigger } from "../ui/sidebar";
 import { useTranslation } from "../../hooks/useTranslation";
+import { STORAGE_KEYS } from "../../utils/constants";
+
+function getAdmin(): { id: number; email: string; name: string; role: string } | null {
+  try {
+    const raw = localStorage.getItem("ruxpress_admin");
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
 
 export default function AdminLayout() {
   const location = useLocation();
+  const navigate = useNavigate();
   const { t } = useTranslation();
   const isActive = (path: string) => location.pathname === path;
-
-  if (location.pathname === "/admin") {
-    const isLoggedIn = true; // TODO: Replace with actual auth check
-    if (!isLoggedIn && location.pathname === "/admin") {
-      return <Navigate to="/admin/login" replace />;
-    }
-  }
 
   if (location.pathname === "/admin/login") {
     return <Outlet />;
   }
 
+  const token = localStorage.getItem(STORAGE_KEYS.TOKEN);
+  const admin = getAdmin();
+
+  if (!token || !admin) {
+    return <Navigate to="/admin/login" replace />;
+  }
+
+  const handleLogout = () => {
+    localStorage.removeItem(STORAGE_KEYS.TOKEN);
+    localStorage.removeItem("ruxpress_admin");
+    navigate("/admin/login");
+  };
+
+  const isSuperAdmin = admin.role === "SUPER_ADMIN";
+
   const navigation = [
-    { nameKey: "nav.admin.dashboard", path: "/admin", icon: LayoutDashboard },
-    { nameKey: "nav.admin.purchaseRequests", path: "/admin/purchase-requests", icon: ShoppingCart },
-    { nameKey: "nav.admin.inquiries", path: "/admin/inquiries", icon: MessageSquare },
-    { nameKey: "nav.admin.notices", path: "/admin/notices", icon: FileText },
-    { nameKey: "nav.admin.exchangeRate", path: "/admin/exchange-rate", icon: TrendingUp },
-    { nameKey: "nav.admin.users", path: "/admin/users", icon: Users },
-  ];
+    { nameKey: "nav.admin.dashboard", path: "/admin", icon: LayoutDashboard, roles: ["SUPER_ADMIN", "COUNSELOR"] },
+    { nameKey: "nav.admin.purchaseRequests", path: "/admin/purchase-requests", icon: ShoppingCart, roles: ["SUPER_ADMIN"] },
+    { nameKey: "nav.admin.inquiries", path: "/admin/inquiries", icon: MessageSquare, roles: ["SUPER_ADMIN", "COUNSELOR"] },
+    { nameKey: "nav.admin.notices", path: "/admin/notices", icon: FileText, roles: ["SUPER_ADMIN"] },
+    { nameKey: "nav.admin.exchangeRate", path: "/admin/exchange-rate", icon: TrendingUp, roles: ["SUPER_ADMIN"] },
+    { nameKey: "nav.admin.users", path: "/admin/users", icon: Users, roles: ["SUPER_ADMIN"] },
+    { nameKey: "nav.admin.admins", path: "/admin/admins", icon: Shield, roles: ["SUPER_ADMIN"] },
+  ].filter((item) => item.roles.includes(admin.role));
 
   return (
     <SidebarProvider>
@@ -70,7 +91,11 @@ export default function AdminLayout() {
               })}
             </SidebarMenu>
             <div className="mt-auto p-4 border-t border-gray-200">
-              <Button variant="ghost" className="w-full justify-start text-red-600 hover:text-red-700 hover:bg-red-50">
+              <Button
+                variant="ghost"
+                className="w-full justify-start text-red-600 hover:text-red-700 hover:bg-red-50"
+                onClick={handleLogout}
+              >
                 <LogOut className="w-4 h-4 mr-2" />
                 {t("nav.admin.logout")}
               </Button>
@@ -87,8 +112,8 @@ export default function AdminLayout() {
             </SidebarTrigger>
             <div className="ml-auto flex items-center space-x-4">
               <div className="text-right">
-                <p className="text-sm font-medium text-gray-900">{t("nav.admin.label")}</p>
-                <p className="text-xs text-gray-500">admin@ruxpress.com</p>
+                <p className="text-sm font-medium text-gray-900">{admin.name}</p>
+                <p className="text-xs text-gray-500">{admin.email}{isSuperAdmin ? " (슈퍼 관리자)" : " (상담사)"}</p>
               </div>
             </div>
           </header>

--- a/front/src/i18n/en.json
+++ b/front/src/i18n/en.json
@@ -12,6 +12,7 @@
   "nav.admin.notices": "Notices",
   "nav.admin.exchangeRate": "Exchange Rate",
   "nav.admin.users": "Users",
+  "nav.admin.admins": "Admin Management",
   "nav.admin.label": "Admin",
   "nav.admin.logout": "Log out",
   "footer.tagline": "Korean products, delivered to Russia",

--- a/front/src/i18n/ko.json
+++ b/front/src/i18n/ko.json
@@ -12,6 +12,7 @@
   "nav.admin.notices": "공지사항 관리",
   "nav.admin.exchangeRate": "환율 설정",
   "nav.admin.users": "회원 관리",
+  "nav.admin.admins": "관리자 관리",
   "nav.admin.label": "관리자",
   "nav.admin.logout": "로그아웃",
   "footer.tagline": "한국 상품 러시아 구매대행 플랫폼",

--- a/front/src/i18n/ru.json
+++ b/front/src/i18n/ru.json
@@ -12,6 +12,7 @@
   "nav.admin.notices": "Новости",
   "nav.admin.exchangeRate": "Курс валют",
   "nav.admin.users": "Пользователи",
+  "nav.admin.admins": "Управление админами",
   "nav.admin.label": "Администратор",
   "nav.admin.logout": "Выход",
   "footer.tagline": "Платформа покупки корейских товаров с доставкой в Россию",

--- a/front/src/pages/admin/AdminAdmins.tsx
+++ b/front/src/pages/admin/AdminAdmins.tsx
@@ -1,0 +1,174 @@
+import { useCallback, useEffect, useState } from "react";
+import { Plus } from "lucide-react";
+import { Button } from "../../components/ui/button";
+import { Badge } from "../../components/ui/badge";
+import { Card, CardContent } from "../../components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../components/ui/table";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "../../components/ui/dialog";
+import { Input } from "../../components/ui/input";
+import { Label } from "../../components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../../components/ui/select";
+import { toast } from "sonner";
+import { api } from "../../utils/api";
+import { unwrap } from "../../utils/exception";
+import type { Admin, AdminRole, AdminStatus } from "../../types";
+
+const roleLabels: Record<AdminRole, string> = {
+  SUPER_ADMIN: "슈퍼 관리자",
+  COUNSELOR: "상담사",
+};
+
+const statusLabels: Record<AdminStatus, { label: string; variant: "default" | "destructive" }> = {
+  ACTIVE: { label: "활성", variant: "default" },
+  INACTIVE: { label: "비활성", variant: "destructive" },
+};
+
+export default function AdminAdmins() {
+  const [admins, setAdmins] = useState<Admin[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [formOpen, setFormOpen] = useState(false);
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [name, setName] = useState("");
+  const [phone, setPhone] = useState("");
+  const [role, setRole] = useState<AdminRole>("COUNSELOR");
+  const [submitting, setSubmitting] = useState(false);
+
+  const loadList = useCallback(() => {
+    setLoading(true);
+    api.get<Admin[]>("/v1/admin/admins")
+      .then((res) => setAdmins(unwrap(res)))
+      .catch(() => { toast.error("관리자 목록을 불러오지 못했습니다"); setAdmins([]); })
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => { loadList(); }, [loadList]);
+
+  const openCreate = () => {
+    setEmail(""); setPassword(""); setName(""); setPhone(""); setRole("COUNSELOR");
+    setFormOpen(true);
+  };
+
+  const handleCreate = async () => {
+    if (!email || !password || !name) { toast.error("필수 항목을 입력해주세요"); return; }
+    setSubmitting(true);
+    try {
+      await api.post<Admin>("/v1/admin/admins", { email, password, name, phone, role });
+      toast.success("관리자 계정이 생성되었습니다");
+      setFormOpen(false);
+      loadList();
+    } catch { toast.error("생성에 실패했습니다"); }
+    finally { setSubmitting(false); }
+  };
+
+  const toggleStatus = async (id: number, currentStatus: AdminStatus) => {
+    const newStatus = currentStatus === "ACTIVE" ? "INACTIVE" : "ACTIVE";
+    try {
+      await api.patch<Admin>(`/v1/admin/admins/${id}/status`, { status: newStatus });
+      toast.success("상태가 변경되었습니다");
+      loadList();
+    } catch { toast.error("상태 변경에 실패했습니다"); }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold text-gray-900">관리자 관리</h1>
+          <p className="text-gray-600 mt-1">관리자 계정을 생성하고 권한을 관리합니다</p>
+        </div>
+        <Button onClick={openCreate}><Plus className="w-4 h-4 mr-2" />관리자 추가</Button>
+      </div>
+
+      <Card>
+        <CardContent className="p-0">
+          {loading ? (
+            <div className="py-12 text-center text-gray-500">불러오는 중...</div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>이메일</TableHead>
+                  <TableHead>이름</TableHead>
+                  <TableHead>역할</TableHead>
+                  <TableHead>상태</TableHead>
+                  <TableHead>최근 로그인</TableHead>
+                  <TableHead>액션</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {admins.length === 0 ? (
+                  <TableRow><TableCell colSpan={6} className="text-center text-gray-500 py-8">관리자가 없습니다</TableCell></TableRow>
+                ) : admins.map((a) => (
+                  <TableRow key={a.id}>
+                    <TableCell>{a.email}</TableCell>
+                    <TableCell className="font-medium">{a.name}</TableCell>
+                    <TableCell>
+                      <Badge variant={a.role === "SUPER_ADMIN" ? "default" : "secondary"}>
+                        {roleLabels[a.role]}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={statusLabels[a.status].variant}>
+                        {statusLabels[a.status].label}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-sm text-gray-500">
+                      {a.lastLoginAt ? new Date(a.lastLoginAt).toLocaleDateString("ko-KR") : "-"}
+                    </TableCell>
+                    <TableCell>
+                      <Button variant="outline" size="sm" onClick={() => toggleStatus(a.id, a.status)}>
+                        {a.status === "ACTIVE" ? "비활성화" : "활성화"}
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog open={formOpen} onOpenChange={setFormOpen}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>관리자 추가</DialogTitle>
+            <DialogDescription>새 관리자 계정을 생성합니다</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label>이메일 *</Label>
+              <Input type="email" value={email} onChange={(e) => setEmail(e.target.value)} placeholder="admin@ruxpress.com" disabled={submitting} />
+            </div>
+            <div className="space-y-2">
+              <Label>비밀번호 *</Label>
+              <Input type="password" value={password} onChange={(e) => setPassword(e.target.value)} placeholder="6자 이상" disabled={submitting} />
+            </div>
+            <div className="space-y-2">
+              <Label>이름 *</Label>
+              <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="관리자 이름" disabled={submitting} />
+            </div>
+            <div className="space-y-2">
+              <Label>전화번호</Label>
+              <Input value={phone} onChange={(e) => setPhone(e.target.value)} placeholder="010-0000-0000" disabled={submitting} />
+            </div>
+            <div className="space-y-2">
+              <Label>역할 *</Label>
+              <Select value={role} onValueChange={(v) => setRole(v as AdminRole)}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="SUPER_ADMIN">슈퍼 관리자</SelectItem>
+                  <SelectItem value="COUNSELOR">상담사</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setFormOpen(false)} disabled={submitting}>취소</Button>
+            <Button onClick={handleCreate} disabled={submitting}>{submitting ? "생성 중..." : "생성"}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/front/src/pages/admin/AdminDashboard.tsx
+++ b/front/src/pages/admin/AdminDashboard.tsx
@@ -1,21 +1,45 @@
-import { Users, ShoppingCart, MessageSquare, TrendingUp, AlertCircle } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { Users, MessageSquare, FileText, TrendingUp, AlertCircle } from "lucide-react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../components/ui/card";
 import { Badge } from "../../components/ui/badge";
-import { mockPurchaseRequests, mockInquiries, mockUsers, currentExchangeRate } from "../../data/mockData";
+import { api } from "../../utils/api";
+import { unwrap } from "../../utils/exception";
+import type { AdminInquiryListItem, PageResponse } from "../../types";
+
+interface DashboardStats {
+  totalUsers: number;
+  newUsersToday: number;
+  totalInquiries: number;
+  pendingInquiries: number;
+  totalNotices: number;
+}
 
 export default function AdminDashboard() {
-  const stats = {
-    totalUsers: mockUsers.length,
-    newUsersToday: 2,
-    totalRequests: mockPurchaseRequests.length,
-    pendingRequests: mockPurchaseRequests.filter(r => r.status === 'REVIEWING').length,
-    totalInquiries: mockInquiries.length,
-    pendingInquiries: mockInquiries.filter(i => i.status === 'PENDING').length,
-    currentExchangeRate: currentExchangeRate.rate,
-  };
+  const [stats, setStats] = useState<DashboardStats | null>(null);
+  const [recentInquiries, setRecentInquiries] = useState<AdminInquiryListItem[]>([]);
+  const [loading, setLoading] = useState(true);
 
-  const recentRequests = mockPurchaseRequests.slice(0, 5);
-  const recentInquiries = mockInquiries.slice(0, 5);
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [statsRes, inqRes] = await Promise.all([
+        api.get<DashboardStats>("/v1/admin/stats/dashboard"),
+        api.get<PageResponse<AdminInquiryListItem>>("/v1/admin/inquiries?page=0&size=5"),
+      ]);
+      setStats(unwrap(statsRes));
+      setRecentInquiries(unwrap(inqRes).content);
+    } catch {
+      // silent
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  if (loading || !stats) {
+    return <div className="py-12 text-center text-gray-500">불러오는 중...</div>;
+  }
 
   return (
     <div className="space-y-6">
@@ -24,128 +48,51 @@ export default function AdminDashboard() {
         <p className="text-gray-600 mt-1">Ruxpress 관리자 현황</p>
       </div>
 
-      {/* Stats Cards */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
         <Card>
           <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium text-gray-600">
-              전체 회원
-            </CardTitle>
+            <CardTitle className="text-sm font-medium text-gray-600">전체 회원</CardTitle>
             <Users className="w-4 h-4 text-blue-600" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-gray-900">
-              {stats.totalUsers}명
-            </div>
-            <p className="text-xs text-green-600 mt-1">
-              오늘 +{stats.newUsersToday}명
-            </p>
+            <div className="text-2xl font-bold text-gray-900">{stats.totalUsers}명</div>
+            <p className="text-xs text-green-600 mt-1">오늘 +{stats.newUsersToday}명</p>
           </CardContent>
         </Card>
 
         <Card>
           <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium text-gray-600">
-              구매 요청
-            </CardTitle>
-            <ShoppingCart className="w-4 h-4 text-green-600" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold text-gray-900">
-              {stats.totalRequests}건
-            </div>
-            <p className="text-xs text-orange-600 mt-1">
-              검토 대기 {stats.pendingRequests}건
-            </p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium text-gray-600">
-              1:1 문의
-            </CardTitle>
+            <CardTitle className="text-sm font-medium text-gray-600">1:1 문의</CardTitle>
             <MessageSquare className="w-4 h-4 text-purple-600" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-gray-900">
-              {stats.totalInquiries}건
-            </div>
-            <p className="text-xs text-orange-600 mt-1">
-              답변 대기 {stats.pendingInquiries}건
-            </p>
+            <div className="text-2xl font-bold text-gray-900">{stats.totalInquiries}건</div>
+            <p className="text-xs text-orange-600 mt-1">답변 대기 {stats.pendingInquiries}건</p>
           </CardContent>
         </Card>
 
         <Card>
           <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium text-gray-600">
-              현재 환율
-            </CardTitle>
+            <CardTitle className="text-sm font-medium text-gray-600">공지사항</CardTitle>
+            <FileText className="w-4 h-4 text-green-600" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold text-gray-900">{stats.totalNotices}건</div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between pb-2">
+            <CardTitle className="text-sm font-medium text-gray-600">현재 환율</CardTitle>
             <TrendingUp className="w-4 h-4 text-indigo-600" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-gray-900">
-              {stats.currentExchangeRate.toFixed(2)}
-            </div>
-            <p className="text-xs text-gray-500 mt-1">
-              1 RUB = {stats.currentExchangeRate.toFixed(2)} KRW
-            </p>
+            <div className="text-2xl font-bold text-gray-900">-</div>
+            <p className="text-xs text-gray-500 mt-1">환율 설정에서 확인</p>
           </CardContent>
         </Card>
       </div>
 
-      {/* Recent Requests */}
-      <Card>
-        <CardHeader>
-          <div className="flex items-center justify-between">
-            <div>
-              <CardTitle>최근 구매 요청</CardTitle>
-              <CardDescription>최근 제출된 구매 요청 목록</CardDescription>
-            </div>
-            {stats.pendingRequests > 0 && (
-              <Badge variant="destructive" className="flex items-center">
-                <AlertCircle className="w-3 h-3 mr-1" />
-                {stats.pendingRequests}건 대기중
-              </Badge>
-            )}
-          </div>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-3">
-            {recentRequests.map((request) => (
-              <div key={request.id} className="flex items-center justify-between p-3 border border-gray-200 rounded-lg hover:bg-gray-50">
-                <div className="flex-1">
-                  <div className="flex items-center space-x-2 mb-1">
-                    <span className="font-medium text-gray-900">
-                      {request.productName}
-                    </span>
-                    <Badge variant={
-                      request.status === 'REVIEWING' ? 'secondary' :
-                      request.status === 'PURCHASING' ? 'default' :
-                      'outline'
-                    }>
-                      {request.status === 'REVIEWING' && '검토중'}
-                      {request.status === 'PURCHASING' && '구매중'}
-                      {request.status === 'DELIVERED' && '배송완료'}
-                    </Badge>
-                  </div>
-                  <p className="text-sm text-gray-500">
-                    {request.requestNumber} · {new Date(request.createdAt).toLocaleDateString('ko-KR')}
-                  </p>
-                </div>
-                <div className="text-right">
-                  <p className="font-semibold text-gray-900">
-                    ₩{request.totalAmountKrw?.toLocaleString()}
-                  </p>
-                </div>
-              </div>
-            ))}
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Recent Inquiries */}
       <Card>
         <CardHeader>
           <div className="flex items-center justify-between">
@@ -163,25 +110,21 @@ export default function AdminDashboard() {
         </CardHeader>
         <CardContent>
           <div className="space-y-3">
-            {recentInquiries.map((inquiry) => (
+            {recentInquiries.length === 0 ? (
+              <p className="text-center text-gray-500 py-4">최근 문의가 없습니다</p>
+            ) : recentInquiries.map((inquiry) => (
               <div key={inquiry.id} className="flex items-start justify-between p-3 border border-gray-200 rounded-lg hover:bg-gray-50">
                 <div className="flex-1">
                   <div className="flex items-center space-x-2 mb-1">
-                    <span className="font-medium text-gray-900">
-                      {inquiry.title}
-                    </span>
-                    <Badge variant={
-                      inquiry.status === 'PENDING' ? 'secondary' :
-                      inquiry.status === 'REPLIED' ? 'default' :
-                      'outline'
-                    }>
-                      {inquiry.status === 'PENDING' && '답변대기'}
-                      {inquiry.status === 'REPLIED' && '답변완료'}
-                      {inquiry.status === 'CLOSED' && '종료'}
+                    <span className="font-medium text-gray-900">{inquiry.title}</span>
+                    <Badge variant={inquiry.status === "PENDING" ? "secondary" : inquiry.status === "REPLIED" ? "default" : "outline"}>
+                      {inquiry.status === "PENDING" && "답변대기"}
+                      {inquiry.status === "REPLIED" && "답변완료"}
+                      {inquiry.status === "CLOSED" && "종료"}
                     </Badge>
                   </div>
                   <p className="text-sm text-gray-500">
-                    {inquiry.category} · {new Date(inquiry.createdAt).toLocaleDateString('ko-KR')}
+                    {inquiry.category} · {new Date(inquiry.createdAt).toLocaleDateString("ko-KR")}
                   </p>
                 </div>
               </div>

--- a/front/src/pages/admin/AdminDashboard.tsx
+++ b/front/src/pages/admin/AdminDashboard.tsx
@@ -1,10 +1,23 @@
 import { useCallback, useEffect, useState } from "react";
-import { Users, MessageSquare, FileText, TrendingUp, AlertCircle } from "lucide-react";
+import { useNavigate } from "react-router";
+import {
+  Users, MessageSquare, FileText, TrendingUp, AlertCircle,
+  Send, ExternalLink, Trash2,
+} from "lucide-react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../components/ui/card";
 import { Badge } from "../../components/ui/badge";
+import { Button } from "../../components/ui/button";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "../../components/ui/dialog";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../components/ui/table";
+import { Textarea } from "../../components/ui/textarea";
+import { Separator } from "../../components/ui/separator";
+import { toast } from "sonner";
 import { api } from "../../utils/api";
 import { unwrap } from "../../utils/exception";
-import type { AdminInquiryListItem, PageResponse } from "../../types";
+import type {
+  AdminInquiryListItem, Inquiry, User, Notice, PageResponse,
+  UserStatus, InquiryStatus, InquiryCategory,
+} from "../../types";
 
 interface DashboardStats {
   totalUsers: number;
@@ -14,10 +27,55 @@ interface DashboardStats {
   totalNotices: number;
 }
 
+interface UserStats {
+  totalUsers: number;
+  activeUsers: number;
+  suspendedUsers: number;
+  withdrawnUsers: number;
+  newUsersToday: number;
+}
+
+const statusVariant: Record<UserStatus, "default" | "destructive" | "outline"> = {
+  ACTIVE: "default", SUSPENDED: "destructive", WITHDRAWN: "outline",
+};
+const statusLabel: Record<UserStatus, string> = {
+  ACTIVE: "정상", SUSPENDED: "정지", WITHDRAWN: "탈퇴",
+};
+const inqStatusLabel: Record<InquiryStatus, string> = {
+  PENDING: "답변대기", REPLIED: "답변완료", CLOSED: "종료",
+};
+const inqStatusVariant: Record<InquiryStatus, "default" | "secondary" | "outline"> = {
+  PENDING: "secondary", REPLIED: "default", CLOSED: "outline",
+};
+const catLabel: Record<InquiryCategory, string> = {
+  ORDER: "주문", SHIPPING: "배송", PAYMENT: "결제", ETC: "기타",
+};
+
+type PopupKind = "users" | "inquiries" | "notices" | null;
+
 export default function AdminDashboard() {
+  const navigate = useNavigate();
   const [stats, setStats] = useState<DashboardStats | null>(null);
   const [recentInquiries, setRecentInquiries] = useState<AdminInquiryListItem[]>([]);
   const [loading, setLoading] = useState(true);
+
+  const [popup, setPopup] = useState<PopupKind>(null);
+
+  // --- users popup ---
+  const [userStats, setUserStats] = useState<UserStats | null>(null);
+  const [users, setUsers] = useState<User[]>([]);
+  const [usersLoading, setUsersLoading] = useState(false);
+
+  // --- inquiries popup ---
+  const [inquiries, setInquiries] = useState<AdminInquiryListItem[]>([]);
+  const [inqLoading, setInqLoading] = useState(false);
+  const [inqDetail, setInqDetail] = useState<Inquiry | null>(null);
+  const [replyText, setReplyText] = useState("");
+  const [replying, setReplying] = useState(false);
+
+  // --- notices popup ---
+  const [notices, setNotices] = useState<Notice[]>([]);
+  const [noticesLoading, setNoticesLoading] = useState(false);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -28,14 +86,96 @@ export default function AdminDashboard() {
       ]);
       setStats(unwrap(statsRes));
       setRecentInquiries(unwrap(inqRes).content);
-    } catch {
-      // silent
-    } finally {
-      setLoading(false);
-    }
+    } catch { /* silent */ }
+    finally { setLoading(false); }
   }, []);
 
   useEffect(() => { load(); }, [load]);
+
+  // popup loaders
+  const openUsers = async () => {
+    setPopup("users");
+    setUsersLoading(true);
+    try {
+      const [s, u] = await Promise.all([
+        api.get<UserStats>("/v1/admin/users/stats"),
+        api.get<PageResponse<User>>("/v1/admin/users?page=0&size=10"),
+      ]);
+      setUserStats(unwrap(s));
+      setUsers(unwrap(u).content);
+    } catch { toast.error("회원 정보를 불러오지 못했습니다"); }
+    finally { setUsersLoading(false); }
+  };
+
+  const changeUserStatus = async (id: number, status: UserStatus) => {
+    try {
+      await api.patch<User>(`/v1/admin/users/${id}/status`, { status });
+      toast.success("상태가 변경되었습니다");
+      openUsers();
+      load();
+    } catch { toast.error("변경 실패"); }
+  };
+
+  const openInquiries = async () => {
+    setPopup("inquiries");
+    setInqDetail(null);
+    setInqLoading(true);
+    try {
+      const res = await api.get<PageResponse<AdminInquiryListItem>>("/v1/admin/inquiries?page=0&size=20");
+      setInquiries(unwrap(res).content);
+    } catch { toast.error("문의 목록을 불러오지 못했습니다"); }
+    finally { setInqLoading(false); }
+  };
+
+  const openInqDetail = async (id: number) => {
+    try {
+      const res = await api.get<Inquiry>(`/v1/admin/inquiries/${id}`);
+      setInqDetail(unwrap(res));
+      setReplyText("");
+    } catch { toast.error("상세 조회 실패"); }
+  };
+
+  const sendReply = async () => {
+    if (!inqDetail || !replyText.trim()) return;
+    setReplying(true);
+    try {
+      const res = await api.post<Inquiry>(`/v1/admin/inquiries/${inqDetail.id}/replies`, { content: replyText.trim() });
+      setInqDetail(unwrap(res));
+      setReplyText("");
+      toast.success("답변이 등록되었습니다");
+      openInquiries();
+      load();
+    } catch { toast.error("답변 등록 실패"); }
+    finally { setReplying(false); }
+  };
+
+  const openNotices = async () => {
+    setPopup("notices");
+    setNoticesLoading(true);
+    try {
+      const res = await api.get<PageResponse<Notice>>("/v1/admin/notices?page=0&size=20");
+      setNotices(unwrap(res).content);
+    } catch { toast.error("공지사항을 불러오지 못했습니다"); }
+    finally { setNoticesLoading(false); }
+  };
+
+  const deleteNotice = async (id: number) => {
+    try {
+      await api.delete<void>(`/v1/admin/notices/${id}`);
+      toast.success("삭제되었습니다");
+      openNotices();
+      load();
+    } catch { toast.error("삭제 실패"); }
+  };
+
+  const togglePin = async (id: number) => {
+    try {
+      await api.patch<Notice>(`/v1/admin/notices/${id}/pin`, {});
+      openNotices();
+    } catch { toast.error("고정 변경 실패"); }
+  };
+
+  const closePopup = () => { setPopup(null); setInqDetail(null); };
 
   if (loading || !stats) {
     return <div className="py-12 text-center text-gray-500">불러오는 중...</div>;
@@ -45,11 +185,11 @@ export default function AdminDashboard() {
     <div className="space-y-6">
       <div>
         <h1 className="text-3xl font-bold text-gray-900">대시보드</h1>
-        <p className="text-gray-600 mt-1">Ruxpress 관리자 현황</p>
+        <p className="text-gray-600 mt-1">Ruxpress 관리자 현황 — 카드를 클릭하면 상세를 볼 수 있습니다</p>
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-        <Card>
+        <Card className="cursor-pointer hover:shadow-lg transition-shadow" onClick={openUsers}>
           <CardHeader className="flex flex-row items-center justify-between pb-2">
             <CardTitle className="text-sm font-medium text-gray-600">전체 회원</CardTitle>
             <Users className="w-4 h-4 text-blue-600" />
@@ -60,7 +200,7 @@ export default function AdminDashboard() {
           </CardContent>
         </Card>
 
-        <Card>
+        <Card className="cursor-pointer hover:shadow-lg transition-shadow" onClick={openInquiries}>
           <CardHeader className="flex flex-row items-center justify-between pb-2">
             <CardTitle className="text-sm font-medium text-gray-600">1:1 문의</CardTitle>
             <MessageSquare className="w-4 h-4 text-purple-600" />
@@ -71,7 +211,7 @@ export default function AdminDashboard() {
           </CardContent>
         </Card>
 
-        <Card>
+        <Card className="cursor-pointer hover:shadow-lg transition-shadow" onClick={openNotices}>
           <CardHeader className="flex flex-row items-center justify-between pb-2">
             <CardTitle className="text-sm font-medium text-gray-600">공지사항</CardTitle>
             <FileText className="w-4 h-4 text-green-600" />
@@ -81,18 +221,19 @@ export default function AdminDashboard() {
           </CardContent>
         </Card>
 
-        <Card>
+        <Card className="cursor-pointer hover:shadow-lg transition-shadow" onClick={() => navigate("/admin/exchange-rate")}>
           <CardHeader className="flex flex-row items-center justify-between pb-2">
             <CardTitle className="text-sm font-medium text-gray-600">현재 환율</CardTitle>
             <TrendingUp className="w-4 h-4 text-indigo-600" />
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold text-gray-900">-</div>
-            <p className="text-xs text-gray-500 mt-1">환율 설정에서 확인</p>
+            <p className="text-xs text-gray-500 mt-1">클릭하여 환율 설정</p>
           </CardContent>
         </Card>
       </div>
 
+      {/* Recent inquiries inline */}
       <Card>
         <CardHeader>
           <div className="flex items-center justify-between">
@@ -113,18 +254,18 @@ export default function AdminDashboard() {
             {recentInquiries.length === 0 ? (
               <p className="text-center text-gray-500 py-4">최근 문의가 없습니다</p>
             ) : recentInquiries.map((inquiry) => (
-              <div key={inquiry.id} className="flex items-start justify-between p-3 border border-gray-200 rounded-lg hover:bg-gray-50">
+              <div
+                key={inquiry.id}
+                className="flex items-start justify-between p-3 border border-gray-200 rounded-lg hover:bg-gray-50 cursor-pointer"
+                onClick={() => { openInquiries().then(() => openInqDetail(inquiry.id)); }}
+              >
                 <div className="flex-1">
                   <div className="flex items-center space-x-2 mb-1">
                     <span className="font-medium text-gray-900">{inquiry.title}</span>
-                    <Badge variant={inquiry.status === "PENDING" ? "secondary" : inquiry.status === "REPLIED" ? "default" : "outline"}>
-                      {inquiry.status === "PENDING" && "답변대기"}
-                      {inquiry.status === "REPLIED" && "답변완료"}
-                      {inquiry.status === "CLOSED" && "종료"}
-                    </Badge>
+                    <Badge variant={inqStatusVariant[inquiry.status]}>{inqStatusLabel[inquiry.status]}</Badge>
                   </div>
                   <p className="text-sm text-gray-500">
-                    {inquiry.category} · {new Date(inquiry.createdAt).toLocaleDateString("ko-KR")}
+                    {catLabel[inquiry.category]} · {new Date(inquiry.createdAt).toLocaleDateString("ko-KR")}
                   </p>
                 </div>
               </div>
@@ -132,6 +273,211 @@ export default function AdminDashboard() {
           </div>
         </CardContent>
       </Card>
+
+      {/* ─── Users Popup ─────────────────────────────── */}
+      <Dialog open={popup === "users"} onOpenChange={(o) => { if (!o) closePopup(); }}>
+        <DialogContent className="max-w-3xl max-h-[85vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>회원 현황</DialogTitle>
+            <DialogDescription>최근 회원 목록 및 상태 관리</DialogDescription>
+          </DialogHeader>
+          {usersLoading ? <div className="py-8 text-center text-gray-500">불러오는 중...</div> : (
+            <>
+              {userStats && (
+                <div className="grid grid-cols-5 gap-3 mb-4">
+                  {[
+                    { l: "전체", v: userStats.totalUsers },
+                    { l: "활성", v: userStats.activeUsers },
+                    { l: "정지", v: userStats.suspendedUsers },
+                    { l: "탈퇴", v: userStats.withdrawnUsers },
+                    { l: "오늘", v: userStats.newUsersToday },
+                  ].map((s) => (
+                    <div key={s.l} className="text-center p-2 bg-gray-50 rounded-lg">
+                      <p className="text-xs text-gray-500">{s.l}</p>
+                      <p className="text-lg font-bold">{s.v}</p>
+                    </div>
+                  ))}
+                </div>
+              )}
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>닉네임</TableHead>
+                    <TableHead>이메일</TableHead>
+                    <TableHead>상태</TableHead>
+                    <TableHead>가입일</TableHead>
+                    <TableHead>변경</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {users.map((u) => (
+                    <TableRow key={u.id}>
+                      <TableCell className="font-medium">{u.nickname}</TableCell>
+                      <TableCell className="text-sm text-gray-500">{u.email}</TableCell>
+                      <TableCell><Badge variant={statusVariant[u.status]}>{statusLabel[u.status]}</Badge></TableCell>
+                      <TableCell className="text-sm text-gray-500">{new Date(u.createdAt).toLocaleDateString("ko-KR")}</TableCell>
+                      <TableCell>
+                        <div className="flex gap-1">
+                          {u.status !== "ACTIVE" && <Button size="sm" variant="outline" onClick={() => changeUserStatus(u.id, "ACTIVE")}>정상</Button>}
+                          {u.status === "ACTIVE" && <Button size="sm" variant="destructive" onClick={() => changeUserStatus(u.id, "SUSPENDED")}>정지</Button>}
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+              <div className="flex justify-end pt-2">
+                <Button variant="outline" size="sm" onClick={() => { closePopup(); navigate("/admin/users"); }}>
+                  <ExternalLink className="w-3 h-3 mr-1" />전체 보기
+                </Button>
+              </div>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      {/* ─── Inquiries Popup ────────────────────────── */}
+      <Dialog open={popup === "inquiries"} onOpenChange={(o) => { if (!o) closePopup(); }}>
+        <DialogContent className="max-w-4xl max-h-[85vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>{inqDetail ? `문의 #${inqDetail.id}` : "문의 현황"}</DialogTitle>
+            <DialogDescription>{inqDetail ? inqDetail.title : "답변 대기 문의를 확인하고 바로 답변할 수 있습니다"}</DialogDescription>
+          </DialogHeader>
+
+          {inqLoading ? <div className="py-8 text-center text-gray-500">불러오는 중...</div> : inqDetail ? (
+            <div className="space-y-4">
+              <Button variant="ghost" size="sm" onClick={() => setInqDetail(null)}>← 목록으로</Button>
+              <div className="p-4 bg-gray-50 rounded-lg">
+                <div className="flex items-center gap-2 mb-2">
+                  <Badge variant="outline">{catLabel[inqDetail.category]}</Badge>
+                  <Badge variant={inqStatusVariant[inqDetail.status]}>{inqStatusLabel[inqDetail.status]}</Badge>
+                  <span className="text-xs text-gray-500">회원 #{inqDetail.userId}</span>
+                </div>
+                <p className="whitespace-pre-wrap text-gray-700">{inqDetail.content}</p>
+              </div>
+
+              {inqDetail.replies && inqDetail.replies.length > 0 && (
+                <div className="space-y-2">
+                  {inqDetail.replies.map((r) => (
+                    <div key={r.id} className="p-3 bg-blue-50 border border-blue-200 rounded-lg">
+                      <div className="flex justify-between text-xs text-gray-500 mb-1">
+                        <span>관리자</span>
+                        <span>{new Date(r.createdAt).toLocaleDateString("ko-KR", { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })}</span>
+                      </div>
+                      <p className="text-sm whitespace-pre-wrap">{r.content}</p>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {inqDetail.status !== "CLOSED" && (
+                <>
+                  <Separator />
+                  <Textarea
+                    placeholder="답변을 입력하세요"
+                    rows={4}
+                    value={replyText}
+                    onChange={(e) => setReplyText(e.target.value)}
+                    disabled={replying}
+                  />
+                  <div className="flex justify-end">
+                    <Button onClick={sendReply} disabled={replying || !replyText.trim()}>
+                      <Send className="w-4 h-4 mr-1" />{replying ? "등록 중..." : "답변 등록"}
+                    </Button>
+                  </div>
+                </>
+              )}
+            </div>
+          ) : (
+            <>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>카테고리</TableHead>
+                    <TableHead>제목</TableHead>
+                    <TableHead>상태</TableHead>
+                    <TableHead>등록일</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {inquiries.length === 0 ? (
+                    <TableRow><TableCell colSpan={4} className="text-center py-6 text-gray-500">문의가 없습니다</TableCell></TableRow>
+                  ) : inquiries.map((inq) => (
+                    <TableRow key={inq.id} className="cursor-pointer hover:bg-gray-50" onClick={() => openInqDetail(inq.id)}>
+                      <TableCell><Badge variant="outline">{catLabel[inq.category]}</Badge></TableCell>
+                      <TableCell className="font-medium">{inq.title}</TableCell>
+                      <TableCell><Badge variant={inqStatusVariant[inq.status]}>{inqStatusLabel[inq.status]}</Badge></TableCell>
+                      <TableCell className="text-sm text-gray-500">{new Date(inq.createdAt).toLocaleDateString("ko-KR")}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+              <div className="flex justify-end pt-2">
+                <Button variant="outline" size="sm" onClick={() => { closePopup(); navigate("/admin/inquiries"); }}>
+                  <ExternalLink className="w-3 h-3 mr-1" />전체 보기
+                </Button>
+              </div>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      {/* ─── Notices Popup ──────────────────────────── */}
+      <Dialog open={popup === "notices"} onOpenChange={(o) => { if (!o) closePopup(); }}>
+        <DialogContent className="max-w-3xl max-h-[85vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>공지사항 관리</DialogTitle>
+            <DialogDescription>공지 목록 확인 및 고정/삭제</DialogDescription>
+          </DialogHeader>
+          {noticesLoading ? <div className="py-8 text-center text-gray-500">불러오는 중...</div> : (
+            <>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>제목</TableHead>
+                    <TableHead>상태</TableHead>
+                    <TableHead>조회</TableHead>
+                    <TableHead>액션</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {notices.length === 0 ? (
+                    <TableRow><TableCell colSpan={4} className="text-center py-6 text-gray-500">공지사항이 없습니다</TableCell></TableRow>
+                  ) : notices.map((n) => (
+                    <TableRow key={n.id}>
+                      <TableCell className="font-medium">
+                        {n.isPinned && <span className="text-yellow-600 mr-1">📌</span>}
+                        {n.title}
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant={n.status === "PUBLISHED" ? "default" : n.status === "DRAFT" ? "outline" : "secondary"}>
+                          {n.status === "PUBLISHED" ? "공개" : n.status === "DRAFT" ? "초안" : n.status === "SCHEDULED" ? "예약" : "숨김"}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-sm text-gray-500">{n.viewCount}</TableCell>
+                      <TableCell>
+                        <div className="flex gap-1">
+                          <Button variant="ghost" size="sm" onClick={() => togglePin(n.id)} title={n.isPinned ? "고정 해제" : "고정"}>
+                            {n.isPinned ? "해제" : "고정"}
+                          </Button>
+                          <Button variant="ghost" size="sm" className="text-red-500" onClick={() => deleteNotice(n.id)}>
+                            <Trash2 className="w-3 h-3" />
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+              <div className="flex justify-end pt-2">
+                <Button variant="outline" size="sm" onClick={() => { closePopup(); navigate("/admin/notices"); }}>
+                  <ExternalLink className="w-3 h-3 mr-1" />전체 보기
+                </Button>
+              </div>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/front/src/pages/admin/AdminExchangeRate.tsx
+++ b/front/src/pages/admin/AdminExchangeRate.tsx
@@ -9,11 +9,13 @@ import { Label } from "../../components/ui/label";
 import { Badge } from "../../components/ui/badge";
 import { toast } from "sonner";
 import {
+  api,
   getCurrentExchangeRate,
   getExchangeRateHistory,
   triggerExchangeRateFetch,
   setManualExchangeRate,
 } from "../../utils/api";
+import { unwrap } from "../../utils/exception";
 import { useTranslation } from "../../hooks/useTranslation";
 import { formatDate, formatNumber } from "../../utils/format";
 import type { ExchangeRate } from "../../types";
@@ -55,8 +57,16 @@ export default function AdminExchangeRate() {
     }
   };
 
+  const loadFeeRate = async () => {
+    try {
+      const res = await api.get<{ key: string; value: string }>("/v1/admin/settings/fee-rate");
+      setFeeRate(unwrap(res).value);
+    } catch { /* keep default */ }
+  };
+
   useEffect(() => {
     loadData();
+    loadFeeRate();
   }, []);
 
   const fetchExchangeRate = async () => {
@@ -91,8 +101,13 @@ export default function AdminExchangeRate() {
     }
   };
 
-  const updateFeeRate = () => {
-    toast.success(t('admin.exchange.toast.feeSuccess'));
+  const updateFeeRate = async () => {
+    try {
+      await api.put<{ key: string; value: string }>("/v1/admin/settings/fee-rate", { value: feeRate });
+      toast.success(t('admin.exchange.toast.feeSuccess'));
+    } catch {
+      toast.error("수수료율 저장에 실패했습니다");
+    }
   };
 
   if (loading && !currentRate) {

--- a/front/src/pages/admin/AdminInquiries.tsx
+++ b/front/src/pages/admin/AdminInquiries.tsx
@@ -1,43 +1,129 @@
-import { useState } from "react";
-import { Search, Send } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { Search, Send, Pencil, Trash2 } from "lucide-react";
 import { Button } from "../../components/ui/button";
 import { Input } from "../../components/ui/input";
 import { Badge } from "../../components/ui/badge";
 import { Card, CardContent } from "../../components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../components/ui/table";
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "../../components/ui/dialog";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "../../components/ui/dialog";
 import { Label } from "../../components/ui/label";
 import { Textarea } from "../../components/ui/textarea";
 import { Separator } from "../../components/ui/separator";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../../components/ui/select";
 import { toast } from "sonner";
-import { mockInquiries } from "../../data/mockData";
-import type { InquiryStatus, InquiryCategory } from "../../types";
+import { api } from "../../utils/api";
+import { unwrap } from "../../utils/exception";
+import type { AdminInquiryListItem, Inquiry, InquiryStatus, InquiryCategory, PageResponse, ReplyTemplate } from "../../types";
 
-const statusLabels: Record<InquiryStatus, { label: string; variant: 'default' | 'secondary' | 'outline' }> = {
-  PENDING: { label: '답변대기', variant: 'secondary' },
-  REPLIED: { label: '답변완료', variant: 'default' },
-  CLOSED: { label: '종료', variant: 'outline' },
+const statusLabels: Record<InquiryStatus, { label: string; variant: "default" | "secondary" | "outline" }> = {
+  PENDING: { label: "답변대기", variant: "secondary" },
+  REPLIED: { label: "답변완료", variant: "default" },
+  CLOSED: { label: "종료", variant: "outline" },
 };
 
 const categoryLabels: Record<InquiryCategory, string> = {
-  ORDER: '주문',
-  SHIPPING: '배송',
-  PAYMENT: '결제',
-  ETC: '기타',
+  ORDER: "주문",
+  SHIPPING: "배송",
+  PAYMENT: "결제",
+  ETC: "기타",
 };
 
 export default function AdminInquiries() {
-  const [selectedInquiry, setSelectedInquiry] = useState<typeof mockInquiries[0] | null>(null);
+  const [items, setItems] = useState<AdminInquiryListItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [detail, setDetail] = useState<Inquiry | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
   const [replyContent, setReplyContent] = useState("");
+  const [replySubmitting, setReplySubmitting] = useState(false);
+  const [editingReplyId, setEditingReplyId] = useState<number | null>(null);
+  const [editContent, setEditContent] = useState("");
+  const [templates, setTemplates] = useState<ReplyTemplate[]>([]);
 
-  const sendReply = () => {
-    if (!replyContent.trim()) {
-      toast.error("답변 내용을 입력해주세요");
-      return;
-    }
-    toast.success("답변이 등록되었습니다");
+  const loadList = useCallback(() => {
+    setLoading(true);
+    api
+      .get<PageResponse<AdminInquiryListItem>>("/v1/admin/inquiries?page=0&size=100")
+      .then((res) => setItems(unwrap(res).content))
+      .catch(() => { toast.error("문의 목록을 불러오지 못했습니다"); setItems([]); })
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => { loadList(); }, [loadList]);
+
+  useEffect(() => {
+    api.get<ReplyTemplate[]>("/v1/admin/reply-templates")
+      .then((res) => setTemplates(unwrap(res)))
+      .catch(() => {});
+  }, []);
+
+  const openDetail = async (id: number) => {
+    setSelectedId(id);
+    setDetailLoading(true);
     setReplyContent("");
+    setEditingReplyId(null);
+    setDialogOpen(true);
+    try {
+      const res = await api.get<Inquiry>(`/v1/admin/inquiries/${id}`);
+      setDetail(unwrap(res));
+    } catch {
+      toast.error("문의 상세를 불러오지 못했습니다");
+      setDetail(null);
+    } finally {
+      setDetailLoading(false);
+    }
   };
+
+  const sendReply = async () => {
+    if (selectedId == null || !replyContent.trim()) {
+      toast.error("답변 내용을 입력해주세요"); return;
+    }
+    setReplySubmitting(true);
+    try {
+      const res = await api.post<Inquiry>(`/v1/admin/inquiries/${selectedId}/replies`, { content: replyContent.trim() });
+      setDetail(unwrap(res));
+      setReplyContent("");
+      toast.success("답변이 등록되었습니다");
+      loadList();
+    } catch { toast.error("답변 등록에 실패했습니다"); }
+    finally { setReplySubmitting(false); }
+  };
+
+  const updateReply = async (replyId: number) => {
+    if (selectedId == null || !editContent.trim()) return;
+    try {
+      const res = await api.put<Inquiry>(`/v1/admin/inquiries/${selectedId}/replies/${replyId}`, { content: editContent.trim() });
+      setDetail(unwrap(res));
+      setEditingReplyId(null);
+      toast.success("답변이 수정되었습니다");
+    } catch { toast.error("수정에 실패했습니다"); }
+  };
+
+  const deleteReply = async (replyId: number) => {
+    if (selectedId == null) return;
+    try {
+      const res = await api.delete<Inquiry>(`/v1/admin/inquiries/${selectedId}/replies/${replyId}`);
+      setDetail(unwrap(res));
+      toast.success("답변이 삭제되었습니다");
+      loadList();
+    } catch { toast.error("삭제에 실패했습니다"); }
+  };
+
+  const changeStatus = async (newStatus: InquiryStatus) => {
+    if (selectedId == null) return;
+    try {
+      const res = await api.patch<Inquiry>(`/v1/admin/inquiries/${selectedId}/status`, { status: newStatus });
+      setDetail(unwrap(res));
+      toast.success("상태가 변경되었습니다");
+      loadList();
+    } catch { toast.error("상태 변경에 실패했습니다"); }
+  };
+
+  const filtered = search.trim()
+    ? items.filter((i) => i.title.toLowerCase().includes(search.toLowerCase()) || String(i.id).includes(search))
+    : items;
 
   return (
     <div className="space-y-6">
@@ -46,167 +132,154 @@ export default function AdminInquiries() {
         <p className="text-gray-600 mt-1">고객 문의에 답변합니다</p>
       </div>
 
-      {/* Search */}
       <Card>
         <CardContent className="pt-6">
           <div className="relative">
             <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-400" />
-            <Input
-              placeholder="제목, 내용 검색"
-              className="pl-10"
-            />
+            <Input placeholder="제목, 문의번호 검색" className="pl-10" value={search} onChange={(e) => setSearch(e.target.value)} />
           </div>
         </CardContent>
       </Card>
 
-      {/* Inquiries Table */}
       <Card>
         <CardContent className="p-0">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>카테고리</TableHead>
-                <TableHead>제목</TableHead>
-                <TableHead>작성자</TableHead>
-                <TableHead>상태</TableHead>
-                <TableHead>등록일</TableHead>
-                <TableHead>액션</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {mockInquiries.map((inquiry) => {
-                const statusInfo = statusLabels[inquiry.status];
-                return (
-                  <TableRow key={inquiry.id}>
+          {loading ? (
+            <div className="py-12 text-center text-gray-500">불러오는 중...</div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>카테고리</TableHead>
+                  <TableHead>제목</TableHead>
+                  <TableHead>작성자</TableHead>
+                  <TableHead>상태</TableHead>
+                  <TableHead>등록일</TableHead>
+                  <TableHead>액션</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filtered.length === 0 ? (
+                  <TableRow><TableCell colSpan={6} className="text-center text-gray-500 py-8">등록된 문의가 없습니다</TableCell></TableRow>
+                ) : filtered.map((inq) => (
+                  <TableRow key={inq.id}>
+                    <TableCell><Badge variant="outline">{categoryLabels[inq.category]}</Badge></TableCell>
+                    <TableCell className="font-medium max-w-xs truncate">{inq.title}</TableCell>
+                    <TableCell className="text-sm text-gray-500">회원 #{inq.userId}</TableCell>
+                    <TableCell><Badge variant={statusLabels[inq.status].variant}>{statusLabels[inq.status].label}</Badge></TableCell>
+                    <TableCell className="text-sm text-gray-500">{new Date(inq.createdAt).toLocaleDateString("ko-KR")}</TableCell>
                     <TableCell>
-                      <Badge variant="outline">
-                        {categoryLabels[inquiry.category]}
-                      </Badge>
-                    </TableCell>
-                    <TableCell className="font-medium max-w-xs truncate">
-                      {inquiry.title}
-                    </TableCell>
-                    <TableCell className="text-sm text-gray-500">
-                      회원 #{inquiry.userId}
-                    </TableCell>
-                    <TableCell>
-                      <Badge variant={statusInfo.variant}>
-                        {statusInfo.label}
-                      </Badge>
-                    </TableCell>
-                    <TableCell className="text-sm text-gray-500">
-                      {new Date(inquiry.createdAt).toLocaleDateString('ko-KR')}
-                    </TableCell>
-                    <TableCell>
-                      <Dialog>
-                        <DialogTrigger asChild>
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => setSelectedInquiry(inquiry)}
-                          >
-                            {inquiry.status === 'PENDING' ? '답변하기' : '보기'}
-                          </Button>
-                        </DialogTrigger>
-                        <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
-                          <DialogHeader>
-                            <DialogTitle>문의 상세</DialogTitle>
-                            <DialogDescription>
-                              {new Date(inquiry.createdAt).toLocaleDateString('ko-KR', {
-                                year: 'numeric',
-                                month: 'long',
-                                day: 'numeric',
-                                hour: '2-digit',
-                                minute: '2-digit'
-                              })}
-                            </DialogDescription>
-                          </DialogHeader>
-                          {selectedInquiry && (
-                            <div className="space-y-4">
-                              {/* Inquiry Content */}
-                              <div className="p-4 bg-gray-50 rounded-lg">
-                                <div className="flex items-center space-x-2 mb-3">
-                                  <Badge variant="outline">
-                                    {categoryLabels[selectedInquiry.category]}
-                                  </Badge>
-                                  <Badge variant={statusLabels[selectedInquiry.status].variant}>
-                                    {statusLabels[selectedInquiry.status].label}
-                                  </Badge>
-                                </div>
-                                <h3 className="font-semibold text-lg mb-2">
-                                  {selectedInquiry.title}
-                                </h3>
-                                <p className="text-gray-700 whitespace-pre-wrap">
-                                  {selectedInquiry.content}
-                                </p>
-                              </div>
-
-                              {/* Existing Replies */}
-                              {selectedInquiry.replies && selectedInquiry.replies.length > 0 && (
-                                <div className="space-y-3">
-                                  <h4 className="font-semibold">답변 내역</h4>
-                                  {selectedInquiry.replies.map((reply) => (
-                                    <div key={reply.id} className="p-4 bg-blue-50 border border-blue-200 rounded-lg">
-                                      <div className="flex items-center justify-between mb-2">
-                                        <div className="flex items-center space-x-2">
-                                          <div className="w-6 h-6 bg-blue-600 rounded-full flex items-center justify-center">
-                                            <span className="text-white text-xs font-bold">R</span>
-                                          </div>
-                                          <span className="font-medium text-sm">관리자</span>
-                                        </div>
-                                        <span className="text-xs text-gray-500">
-                                          {new Date(reply.createdAt).toLocaleDateString('ko-KR', {
-                                            year: 'numeric',
-                                            month: 'long',
-                                            day: 'numeric',
-                                            hour: '2-digit',
-                                            minute: '2-digit'
-                                          })}
-                                        </span>
-                                      </div>
-                                      <Separator className="my-2 bg-blue-200" />
-                                      <p className="text-gray-700 text-sm whitespace-pre-wrap">
-                                        {reply.content}
-                                      </p>
-                                    </div>
-                                  ))}
-                                </div>
-                              )}
-
-                              {/* Reply Form */}
-                              {selectedInquiry.status !== 'CLOSED' && (
-                                <div className="space-y-3">
-                                  <Separator />
-                                  <div className="space-y-2">
-                                    <Label>답변 작성</Label>
-                                    <Textarea
-                                      placeholder="답변 내용을 입력하세요"
-                                      rows={6}
-                                      value={replyContent}
-                                      onChange={(e) => setReplyContent(e.target.value)}
-                                    />
-                                  </div>
-                                  <div className="flex justify-end space-x-2">
-                                    <Button variant="outline">답변 템플릿</Button>
-                                    <Button onClick={sendReply}>
-                                      <Send className="w-4 h-4 mr-2" />
-                                      답변 등록
-                                    </Button>
-                                  </div>
-                                </div>
-                              )}
-                            </div>
-                          )}
-                        </DialogContent>
-                      </Dialog>
+                      <Button variant="outline" size="sm" onClick={() => openDetail(inq.id)}>
+                        {inq.status === "PENDING" ? "답변하기" : "보기"}
+                      </Button>
                     </TableCell>
                   </TableRow>
-                );
-              })}
-            </TableBody>
-          </Table>
+                ))}
+              </TableBody>
+            </Table>
+          )}
         </CardContent>
       </Card>
+
+      <Dialog open={dialogOpen} onOpenChange={(o) => { setDialogOpen(o); if (!o) { setSelectedId(null); setDetail(null); setEditingReplyId(null); } }}>
+        <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>문의 상세</DialogTitle>
+            <DialogDescription>
+              {detail && new Date(detail.createdAt).toLocaleDateString("ko-KR", { year: "numeric", month: "long", day: "numeric", hour: "2-digit", minute: "2-digit" })}
+            </DialogDescription>
+          </DialogHeader>
+          {detailLoading && <div className="py-8 text-center text-gray-500">불러오는 중...</div>}
+          {!detailLoading && detail && (
+            <div className="space-y-4">
+              <div className="p-4 bg-gray-50 rounded-lg">
+                <div className="flex items-center space-x-2 mb-3">
+                  <Badge variant="outline">{categoryLabels[detail.category]}</Badge>
+                  <Badge variant={statusLabels[detail.status].variant}>{statusLabels[detail.status].label}</Badge>
+                  <span className="text-sm text-gray-500">회원 #{detail.userId}</span>
+                  <div className="ml-auto">
+                    <Select value={detail.status} onValueChange={(v) => changeStatus(v as InquiryStatus)}>
+                      <SelectTrigger className="w-[130px] h-8 text-xs"><SelectValue /></SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="PENDING">답변대기</SelectItem>
+                        <SelectItem value="REPLIED">답변완료</SelectItem>
+                        <SelectItem value="CLOSED">종료</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+                <h3 className="font-semibold text-lg mb-2">{detail.title}</h3>
+                <p className="text-gray-700 whitespace-pre-wrap">{detail.content}</p>
+              </div>
+
+              {detail.replies && detail.replies.length > 0 && (
+                <div className="space-y-3">
+                  <h4 className="font-semibold">답변 내역</h4>
+                  {detail.replies.map((reply) => (
+                    <div key={reply.id} className="p-4 bg-blue-50 border border-blue-200 rounded-lg">
+                      <div className="flex items-center justify-between mb-2">
+                        <div className="flex items-center space-x-2">
+                          <div className="w-6 h-6 bg-blue-600 rounded-full flex items-center justify-center">
+                            <span className="text-white text-xs font-bold">R</span>
+                          </div>
+                          <span className="font-medium text-sm">관리자</span>
+                        </div>
+                        <div className="flex items-center space-x-2">
+                          <span className="text-xs text-gray-500">
+                            {new Date(reply.createdAt).toLocaleDateString("ko-KR", { year: "numeric", month: "long", day: "numeric", hour: "2-digit", minute: "2-digit" })}
+                          </span>
+                          <Button variant="ghost" size="icon" className="h-6 w-6" onClick={() => { setEditingReplyId(reply.id); setEditContent(reply.content); }}>
+                            <Pencil className="w-3 h-3" />
+                          </Button>
+                          <Button variant="ghost" size="icon" className="h-6 w-6 text-red-500" onClick={() => deleteReply(reply.id)}>
+                            <Trash2 className="w-3 h-3" />
+                          </Button>
+                        </div>
+                      </div>
+                      <Separator className="my-2 bg-blue-200" />
+                      {editingReplyId === reply.id ? (
+                        <div className="space-y-2">
+                          <Textarea value={editContent} onChange={(e) => setEditContent(e.target.value)} rows={4} />
+                          <div className="flex gap-2">
+                            <Button size="sm" onClick={() => updateReply(reply.id)}>저장</Button>
+                            <Button size="sm" variant="outline" onClick={() => setEditingReplyId(null)}>취소</Button>
+                          </div>
+                        </div>
+                      ) : (
+                        <p className="text-gray-700 text-sm whitespace-pre-wrap">{reply.content}</p>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {detail.status !== "CLOSED" && (
+                <div className="space-y-3">
+                  <Separator />
+                  <div className="space-y-2">
+                    <div className="flex items-center justify-between">
+                      <Label>답변 작성</Label>
+                      {templates.length > 0 && (
+                        <Select onValueChange={(v) => { const tpl = templates.find(t => String(t.id) === v); if (tpl) setReplyContent(tpl.content); }}>
+                          <SelectTrigger className="w-[200px] h-8 text-xs"><SelectValue placeholder="템플릿 선택" /></SelectTrigger>
+                          <SelectContent>
+                            {templates.map((tpl) => <SelectItem key={tpl.id} value={String(tpl.id)}>{tpl.title}</SelectItem>)}
+                          </SelectContent>
+                        </Select>
+                      )}
+                    </div>
+                    <Textarea placeholder="답변 내용을 입력하세요" rows={6} value={replyContent} onChange={(e) => setReplyContent(e.target.value)} disabled={replySubmitting} />
+                  </div>
+                  <div className="flex justify-end">
+                    <Button onClick={sendReply} disabled={replySubmitting}>
+                      <Send className="w-4 h-4 mr-2" />답변 등록
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/front/src/pages/admin/AdminLogin.tsx
+++ b/front/src/pages/admin/AdminLogin.tsx
@@ -1,15 +1,48 @@
+import { useState } from "react";
 import { useNavigate } from "react-router";
 import { Button } from "../../components/ui/button";
 import { Input } from "../../components/ui/input";
 import { Label } from "../../components/ui/label";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../components/ui/card";
+import { toast } from "sonner";
+import { api } from "../../utils/api";
+import { unwrap } from "../../utils/exception";
+import { STORAGE_KEYS } from "../../utils/constants";
+
+interface LoginResponse {
+  token: string;
+  adminId: number;
+  email: string;
+  name: string;
+  role: string;
+}
 
 export default function AdminLogin() {
   const navigate = useNavigate();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    navigate("/admin");
+    setLoading(true);
+    try {
+      const res = await api.post<LoginResponse>("/v1/admin/auth/login", { email, password });
+      const data = unwrap(res);
+      localStorage.setItem(STORAGE_KEYS.TOKEN, data.token);
+      localStorage.setItem("ruxpress_admin", JSON.stringify({
+        id: data.adminId,
+        email: data.email,
+        name: data.name,
+        role: data.role,
+      }));
+      toast.success(`${data.name}님, 환영합니다`);
+      navigate("/admin");
+    } catch {
+      toast.error("이메일 또는 비밀번호가 올바르지 않습니다");
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
@@ -34,7 +67,10 @@ export default function AdminLogin() {
                 id="admin-email"
                 type="email"
                 placeholder="admin@ruxpress.com"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
                 required
+                disabled={loading}
               />
             </div>
             <div className="space-y-2">
@@ -43,11 +79,14 @@ export default function AdminLogin() {
                 id="admin-password"
                 type="password"
                 placeholder="••••••••"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
                 required
+                disabled={loading}
               />
             </div>
-            <Button type="submit" className="w-full" size="lg">
-              로그인
+            <Button type="submit" className="w-full" size="lg" disabled={loading}>
+              {loading ? "로그인 중..." : "로그인"}
             </Button>
           </form>
         </CardContent>

--- a/front/src/pages/admin/AdminNotices.tsx
+++ b/front/src/pages/admin/AdminNotices.tsx
@@ -1,41 +1,100 @@
-import { useState } from "react";
-import { Plus, Edit, Trash2, Pin } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { Plus, Pin, PinOff, Pencil, Trash2 } from "lucide-react";
 import { Button } from "../../components/ui/button";
-import { Input } from "../../components/ui/input";
 import { Badge } from "../../components/ui/badge";
 import { Card, CardContent } from "../../components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../components/ui/table";
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "../../components/ui/dialog";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogFooter } from "../../components/ui/dialog";
+import { Input } from "../../components/ui/input";
 import { Label } from "../../components/ui/label";
 import { Textarea } from "../../components/ui/textarea";
-import { Switch } from "../../components/ui/switch";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../../components/ui/select";
 import { toast } from "sonner";
-import { mockNotices } from "../../data/mockData";
-import type { NoticeStatus } from "../../types";
+import { api } from "../../utils/api";
+import { unwrap } from "../../utils/exception";
+import type { Notice, NoticeStatus, PageResponse } from "../../types";
 
-const statusLabels: Record<NoticeStatus, { label: string; variant: 'default' | 'secondary' | 'outline' | 'destructive' }> = {
-  DRAFT: { label: '작성중', variant: 'outline' },
-  SCHEDULED: { label: '예약', variant: 'secondary' },
-  PUBLISHED: { label: '발행됨', variant: 'default' },
-  HIDDEN: { label: '숨김', variant: 'destructive' },
+const statusLabels: Record<NoticeStatus, { label: string; variant: "default" | "secondary" | "outline" | "destructive" }> = {
+  DRAFT: { label: "초안", variant: "outline" },
+  SCHEDULED: { label: "예약", variant: "secondary" },
+  PUBLISHED: { label: "공개", variant: "default" },
+  HIDDEN: { label: "숨김", variant: "destructive" },
 };
 
 export default function AdminNotices() {
-  const [isCreateOpen, setIsCreateOpen] = useState(false);
-  const [title, setTitle] = useState("");
-  const [content, setContent] = useState("");
-  const [isPinned, setIsPinned] = useState(false);
+  const [notices, setNotices] = useState<Notice[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [formOpen, setFormOpen] = useState(false);
+  const [editTarget, setEditTarget] = useState<Notice | null>(null);
+  const [formTitle, setFormTitle] = useState("");
+  const [formContent, setFormContent] = useState("");
+  const [formPinned, setFormPinned] = useState(false);
+  const [formStatus, setFormStatus] = useState<string>("PUBLISHED");
+  const [formScheduledAt, setFormScheduledAt] = useState("");
+  const [submitting, setSubmitting] = useState(false);
 
-  const createNotice = () => {
-    if (!title.trim() || !content.trim()) {
-      toast.error("제목과 내용을 입력해주세요");
-      return;
-    }
-    toast.success("공지사항이 등록되었습니다");
-    setIsCreateOpen(false);
-    setTitle("");
-    setContent("");
-    setIsPinned(false);
+  const loadList = useCallback(() => {
+    setLoading(true);
+    api.get<PageResponse<Notice>>("/v1/admin/notices?page=0&size=100")
+      .then((res) => setNotices(unwrap(res).content))
+      .catch(() => { toast.error("공지사항을 불러오지 못했습니다"); setNotices([]); })
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => { loadList(); }, [loadList]);
+
+  const openCreate = () => {
+    setEditTarget(null);
+    setFormTitle("");
+    setFormContent("");
+    setFormPinned(false);
+    setFormStatus("PUBLISHED");
+    setFormScheduledAt("");
+    setFormOpen(true);
+  };
+
+  const openEdit = (n: Notice) => {
+    setEditTarget(n);
+    setFormTitle(n.title);
+    setFormContent(n.content);
+    setFormPinned(n.isPinned);
+    setFormStatus(n.status);
+    setFormScheduledAt(n.scheduledAt ? n.scheduledAt.slice(0, 16) : "");
+    setFormOpen(true);
+  };
+
+  const handleSubmit = async () => {
+    if (!formTitle.trim() || !formContent.trim()) { toast.error("제목과 내용을 입력해주세요"); return; }
+    setSubmitting(true);
+    try {
+      if (editTarget) {
+        await api.put<Notice>(`/v1/admin/notices/${editTarget.id}`, { title: formTitle.trim(), content: formContent.trim(), isPinned: formPinned });
+        toast.success("공지사항이 수정되었습니다");
+      } else {
+        const body: Record<string, unknown> = { title: formTitle.trim(), content: formContent.trim(), isPinned: formPinned, status: formStatus };
+        if (formStatus === "SCHEDULED" && formScheduledAt) body.scheduledAt = formScheduledAt + ":00";
+        await api.post<Notice>("/v1/admin/notices", body);
+        toast.success("공지사항이 등록되었습니다");
+      }
+      setFormOpen(false);
+      loadList();
+    } catch { toast.error("저장에 실패했습니다"); }
+    finally { setSubmitting(false); }
+  };
+
+  const handleDelete = async (id: number) => {
+    try {
+      await api.delete<void>(`/v1/admin/notices/${id}`);
+      toast.success("삭제되었습니다");
+      loadList();
+    } catch { toast.error("삭제에 실패했습니다"); }
+  };
+
+  const togglePin = async (id: number) => {
+    try {
+      await api.patch<Notice>(`/v1/admin/notices/${id}/pin`, {});
+      loadList();
+    } catch { toast.error("고정 변경에 실패했습니다"); }
   };
 
   return (
@@ -45,137 +104,96 @@ export default function AdminNotices() {
           <h1 className="text-3xl font-bold text-gray-900">공지사항 관리</h1>
           <p className="text-gray-600 mt-1">공지사항을 작성하고 관리합니다</p>
         </div>
-        <Dialog open={isCreateOpen} onOpenChange={setIsCreateOpen}>
-          <DialogTrigger asChild>
-            <Button>
-              <Plus className="w-4 h-4 mr-2" />
-              새 공지사항
-            </Button>
-          </DialogTrigger>
-          <DialogContent className="max-w-3xl">
-            <DialogHeader>
-              <DialogTitle>공지사항 작성</DialogTitle>
-              <DialogDescription>
-                새로운 공지사항을 작성합니다
-              </DialogDescription>
-            </DialogHeader>
-            <div className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="notice-title">제목 *</Label>
-                <Input
-                  id="notice-title"
-                  placeholder="공지사항 제목을 입력하세요"
-                  value={title}
-                  onChange={(e) => setTitle(e.target.value)}
-                />
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="notice-content">내용 *</Label>
-                <Textarea
-                  id="notice-content"
-                  placeholder="공지사항 내용을 입력하세요 (HTML 지원)"
-                  rows={10}
-                  value={content}
-                  onChange={(e) => setContent(e.target.value)}
-                />
-                <p className="text-xs text-gray-500">
-                  HTML 태그를 사용할 수 있습니다 (예: &lt;p&gt;, &lt;strong&gt;, &lt;br&gt;)
-                </p>
-              </div>
-
-              <div className="flex items-center justify-between p-3 border border-gray-200 rounded-lg">
-                <div>
-                  <Label htmlFor="notice-pinned" className="cursor-pointer">
-                    상단 고정
-                  </Label>
-                  <p className="text-sm text-gray-500">
-                    중요 공지사항을 맨 위에 고정합니다
-                  </p>
-                </div>
-                <Switch
-                  id="notice-pinned"
-                  checked={isPinned}
-                  onCheckedChange={setIsPinned}
-                />
-              </div>
-
-              <div className="flex justify-end space-x-2">
-                <Button variant="outline" onClick={() => setIsCreateOpen(false)}>
-                  취소
-                </Button>
-                <Button variant="outline">
-                  임시저장
-                </Button>
-                <Button onClick={createNotice}>
-                  발행
-                </Button>
-              </div>
-            </div>
-          </DialogContent>
-        </Dialog>
+        <Button onClick={openCreate}><Plus className="w-4 h-4 mr-2" />공지 작성</Button>
       </div>
 
-      {/* Notices Table */}
       <Card>
         <CardContent className="p-0">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>제목</TableHead>
-                <TableHead>상태</TableHead>
-                <TableHead>조회수</TableHead>
-                <TableHead>발행일</TableHead>
-                <TableHead>작성자</TableHead>
-                <TableHead>액션</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {mockNotices.map((notice) => {
-                const statusInfo = statusLabels[notice.status];
-                return (
-                  <TableRow key={notice.id}>
+          {loading ? (
+            <div className="py-12 text-center text-gray-500">불러오는 중...</div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-10"></TableHead>
+                  <TableHead>제목</TableHead>
+                  <TableHead>상태</TableHead>
+                  <TableHead>조회수</TableHead>
+                  <TableHead>등록일</TableHead>
+                  <TableHead>액션</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {notices.length === 0 ? (
+                  <TableRow><TableCell colSpan={6} className="text-center text-gray-500 py-8">공지사항이 없습니다</TableCell></TableRow>
+                ) : notices.map((n) => (
+                  <TableRow key={n.id}>
+                    <TableCell>{n.isPinned && <Pin className="w-4 h-4 text-blue-500" />}</TableCell>
+                    <TableCell className="font-medium max-w-md truncate">{n.title}</TableCell>
+                    <TableCell><Badge variant={statusLabels[n.status].variant}>{statusLabels[n.status].label}</Badge></TableCell>
+                    <TableCell className="text-sm text-gray-500">{n.viewCount}</TableCell>
+                    <TableCell className="text-sm text-gray-500">{new Date(n.createdAt).toLocaleDateString("ko-KR")}</TableCell>
                     <TableCell>
-                      <div className="flex items-center space-x-2">
-                        {notice.isPinned && (
-                          <Pin className="w-4 h-4 text-yellow-600" />
-                        )}
-                        <span className="font-medium">{notice.title}</span>
-                      </div>
-                    </TableCell>
-                    <TableCell>
-                      <Badge variant={statusInfo.variant}>
-                        {statusInfo.label}
-                      </Badge>
-                    </TableCell>
-                    <TableCell className="text-sm text-gray-500">
-                      {notice.viewCount.toLocaleString()}
-                    </TableCell>
-                    <TableCell className="text-sm text-gray-500">
-                      {notice.publishedAt
-                        ? new Date(notice.publishedAt).toLocaleDateString('ko-KR')
-                        : '-'}
-                    </TableCell>
-                    <TableCell className="text-sm text-gray-500">
-                      관리자
-                    </TableCell>
-                    <TableCell>
-                      <div className="flex space-x-2">
-                        <Button variant="ghost" size="sm">
-                          <Edit className="w-4 h-4" />
+                      <div className="flex gap-1">
+                        <Button variant="ghost" size="icon" className="h-8 w-8" onClick={() => togglePin(n.id)} title={n.isPinned ? "고정 해제" : "고정"}>
+                          {n.isPinned ? <PinOff className="w-4 h-4" /> : <Pin className="w-4 h-4" />}
                         </Button>
-                        <Button variant="ghost" size="sm" className="text-red-600 hover:text-red-700">
-                          <Trash2 className="w-4 h-4" />
-                        </Button>
+                        <Button variant="ghost" size="icon" className="h-8 w-8" onClick={() => openEdit(n)}><Pencil className="w-4 h-4" /></Button>
+                        <Button variant="ghost" size="icon" className="h-8 w-8 text-red-500" onClick={() => handleDelete(n.id)}><Trash2 className="w-4 h-4" /></Button>
                       </div>
                     </TableCell>
                   </TableRow>
-                );
-              })}
-            </TableBody>
-          </Table>
+                ))}
+              </TableBody>
+            </Table>
+          )}
         </CardContent>
       </Card>
+
+      <Dialog open={formOpen} onOpenChange={setFormOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>{editTarget ? "공지사항 수정" : "공지사항 작성"}</DialogTitle>
+            <DialogDescription>{editTarget ? "공지사항을 수정합니다" : "새 공지사항을 작성합니다"}</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label>제목</Label>
+              <Input value={formTitle} onChange={(e) => setFormTitle(e.target.value)} placeholder="공지사항 제목" disabled={submitting} />
+            </div>
+            <div className="space-y-2">
+              <Label>내용</Label>
+              <Textarea value={formContent} onChange={(e) => setFormContent(e.target.value)} placeholder="공지사항 내용" rows={10} disabled={submitting} />
+            </div>
+            <div className="flex items-center gap-4">
+              <label className="flex items-center gap-2 text-sm">
+                <input type="checkbox" checked={formPinned} onChange={(e) => setFormPinned(e.target.checked)} />
+                중요 공지 (상단 고정)
+              </label>
+            </div>
+            {!editTarget && (
+              <div className="space-y-2">
+                <Label>발행 방법</Label>
+                <Select value={formStatus} onValueChange={setFormStatus}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="PUBLISHED">즉시 발행</SelectItem>
+                    <SelectItem value="SCHEDULED">예약 발행</SelectItem>
+                    <SelectItem value="DRAFT">초안 저장</SelectItem>
+                  </SelectContent>
+                </Select>
+                {formStatus === "SCHEDULED" && (
+                  <Input type="datetime-local" value={formScheduledAt} onChange={(e) => setFormScheduledAt(e.target.value)} disabled={submitting} />
+                )}
+              </div>
+            )}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setFormOpen(false)} disabled={submitting}>취소</Button>
+            <Button onClick={handleSubmit} disabled={submitting}>{submitting ? "저장 중..." : "저장"}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/front/src/pages/admin/AdminUsers.tsx
+++ b/front/src/pages/admin/AdminUsers.tsx
@@ -1,95 +1,135 @@
-import { Search, UserCheck, UserX, Mail, Phone } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { Search } from "lucide-react";
 import { Button } from "../../components/ui/button";
 import { Input } from "../../components/ui/input";
 import { Badge } from "../../components/ui/badge";
 import { Card, CardContent } from "../../components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../components/ui/table";
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "../../components/ui/dialog";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "../../components/ui/dialog";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../../components/ui/select";
 import { toast } from "sonner";
-import { mockUsers } from "../../data/mockData";
-import type { UserStatus } from "../../types";
+import { api } from "../../utils/api";
+import { unwrap } from "../../utils/exception";
+import type { User, UserStatus, PageResponse } from "../../types";
 
-const statusLabels: Record<UserStatus, { label: string; variant: 'default' | 'secondary' | 'destructive' }> = {
-  ACTIVE: { label: '정상', variant: 'default' },
-  SUSPENDED: { label: '정지', variant: 'destructive' },
-  WITHDRAWN: { label: '탈퇴', variant: 'secondary' },
+const statusLabels: Record<UserStatus, { label: string; variant: "default" | "secondary" | "outline" | "destructive" }> = {
+  ACTIVE: { label: "정상", variant: "default" },
+  SUSPENDED: { label: "정지", variant: "destructive" },
+  WITHDRAWN: { label: "탈퇴", variant: "outline" },
 };
 
+interface UserStats {
+  totalUsers: number;
+  activeUsers: number;
+  suspendedUsers: number;
+  withdrawnUsers: number;
+  newUsersToday: number;
+}
+
 export default function AdminUsers() {
-  const updateUserStatus = (_userId: number, _newStatus: UserStatus) => {
-    toast.success("회원 상태가 변경되었습니다");
+  const [users, setUsers] = useState<User[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState<string>("ALL");
+  const [stats, setStats] = useState<UserStats | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [selectedUser, setSelectedUser] = useState<User | null>(null);
+
+  const loadUsers = useCallback(() => {
+    setLoading(true);
+    const params = new URLSearchParams({ page: "0", size: "100" });
+    if (search.trim()) params.set("keyword", search.trim());
+    if (statusFilter !== "ALL") params.set("status", statusFilter);
+
+    api
+      .get<PageResponse<User>>(`/v1/admin/users?${params}`)
+      .then((res) => setUsers(unwrap(res).content))
+      .catch(() => {
+        toast.error("회원 목록을 불러오지 못했습니다");
+        setUsers([]);
+      })
+      .finally(() => setLoading(false));
+  }, [search, statusFilter]);
+
+  const loadStats = useCallback(() => {
+    api
+      .get<UserStats>("/v1/admin/users/stats")
+      .then((res) => setStats(unwrap(res)))
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    loadUsers();
+    loadStats();
+  }, [loadUsers, loadStats]);
+
+  const openDetail = async (id: number) => {
+    try {
+      const res = await api.get<User>(`/v1/admin/users/${id}`);
+      setSelectedUser(unwrap(res));
+      setDialogOpen(true);
+    } catch {
+      toast.error("회원 정보를 불러오지 못했습니다");
+    }
+  };
+
+  const updateStatus = async (userId: number, status: UserStatus) => {
+    try {
+      const res = await api.patch<User>(`/v1/admin/users/${userId}/status`, { status });
+      const updated = unwrap(res);
+      setSelectedUser(updated);
+      toast.success("회원 상태가 변경되었습니다");
+      loadUsers();
+      loadStats();
+    } catch {
+      toast.error("상태 변경에 실패했습니다");
+    }
   };
 
   return (
     <div className="space-y-6">
       <div>
         <h1 className="text-3xl font-bold text-gray-900">회원 관리</h1>
-        <p className="text-gray-600 mt-1">회원 정보를 조회하고 관리합니다</p>
+        <p className="text-gray-600 mt-1">회원 목록 조회 및 상태를 관리합니다</p>
       </div>
 
-      {/* Stats */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-        <Card>
-          <CardContent className="pt-6">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-sm text-gray-600">전체 회원</p>
-                <p className="text-2xl font-bold text-gray-900 mt-1">
-                  {mockUsers.length}명
-                </p>
-              </div>
-              <UserCheck className="w-8 h-8 text-blue-600" />
-            </div>
-          </CardContent>
-        </Card>
+      {stats && (
+        <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+          {[
+            { label: "전체 회원", value: stats.totalUsers },
+            { label: "활성", value: stats.activeUsers },
+            { label: "정지", value: stats.suspendedUsers },
+            { label: "탈퇴", value: stats.withdrawnUsers },
+            { label: "오늘 가입", value: stats.newUsersToday },
+          ].map((s) => (
+            <Card key={s.label}>
+              <CardContent className="pt-4 pb-4 text-center">
+                <p className="text-sm text-gray-500">{s.label}</p>
+                <p className="text-2xl font-bold">{s.value}</p>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
 
-        <Card>
-          <CardContent className="pt-6">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-sm text-gray-600">정상 회원</p>
-                <p className="text-2xl font-bold text-green-600 mt-1">
-                  {mockUsers.filter(u => u.status === 'ACTIVE').length}명
-                </p>
-              </div>
-              <UserCheck className="w-8 h-8 text-green-600" />
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardContent className="pt-6">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-sm text-gray-600">정지/탈퇴</p>
-                <p className="text-2xl font-bold text-red-600 mt-1">
-                  {mockUsers.filter(u => u.status !== 'ACTIVE').length}명
-                </p>
-              </div>
-              <UserX className="w-8 h-8 text-red-600" />
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-
-      {/* Search */}
       <Card>
         <CardContent className="pt-6">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div className="relative">
+          <div className="flex gap-4">
+            <div className="relative flex-1">
               <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-400" />
               <Input
-                placeholder="이메일, 닉네임, 전화번호 검색"
+                placeholder="이메일, 닉네임 검색"
                 className="pl-10"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
               />
             </div>
-            <Select defaultValue="all">
-              <SelectTrigger>
-                <SelectValue placeholder="상태 필터" />
+            <Select value={statusFilter} onValueChange={setStatusFilter}>
+              <SelectTrigger className="w-[150px]">
+                <SelectValue placeholder="상태" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="all">전체</SelectItem>
+                <SelectItem value="ALL">전체</SelectItem>
                 <SelectItem value="ACTIVE">정상</SelectItem>
                 <SelectItem value="SUSPENDED">정지</SelectItem>
                 <SelectItem value="WITHDRAWN">탈퇴</SelectItem>
@@ -99,122 +139,99 @@ export default function AdminUsers() {
         </CardContent>
       </Card>
 
-      {/* Users Table */}
       <Card>
         <CardContent className="p-0">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>회원 정보</TableHead>
-                <TableHead>연락처</TableHead>
-                <TableHead>가입 유형</TableHead>
-                <TableHead>상태</TableHead>
-                <TableHead>가입일</TableHead>
-                <TableHead>액션</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {mockUsers.map((user) => {
-                const statusInfo = statusLabels[user.status];
-                return (
-                  <TableRow key={user.id}>
-                    <TableCell>
-                      <div>
-                        <p className="font-medium text-gray-900">{user.nickname}</p>
-                        <p className="text-sm text-gray-500">ID: {user.id}</p>
-                      </div>
-                    </TableCell>
-                    <TableCell>
-                      <div className="space-y-1">
-                        <div className="flex items-center text-sm">
-                          <Mail className="w-3 h-3 mr-1 text-gray-400" />
-                          <span className="text-gray-600">{user.email}</span>
-                          {user.emailVerified && (
-                            <Badge variant="default" className="ml-2 text-xs bg-green-500">인증</Badge>
-                          )}
-                        </div>
-                        {user.phone && (
-                          <div className="flex items-center text-sm">
-                            <Phone className="w-3 h-3 mr-1 text-gray-400" />
-                            <span className="text-gray-600">{user.phone}</span>
-                            {user.phoneVerified && (
-                              <Badge variant="default" className="ml-2 text-xs bg-green-500">인증</Badge>
-                            )}
-                          </div>
-                        )}
-                      </div>
-                    </TableCell>
-                    <TableCell>
-                      <Badge variant="outline">
-                        {user.signupType === 'EMAIL' ? '이메일' :
-                         user.signupType === 'PHONE' ? '휴대폰' :
-                         'Google'}
-                      </Badge>
-                    </TableCell>
-                    <TableCell>
-                      <Badge variant={statusInfo.variant}>
-                        {statusInfo.label}
-                      </Badge>
-                    </TableCell>
-                    <TableCell className="text-sm text-gray-500">
-                      {new Date(user.createdAt).toLocaleDateString('ko-KR')}
-                    </TableCell>
-                    <TableCell>
-                      <Dialog>
-                        <DialogTrigger asChild>
-                          <Button variant="outline" size="sm">
-                            관리
-                          </Button>
-                        </DialogTrigger>
-                        <DialogContent>
-                          <DialogHeader>
-                            <DialogTitle>회원 상세 정보</DialogTitle>
-                            <DialogDescription>
-                              회원 정보를 조회하고 상태를 변경합니다
-                            </DialogDescription>
-                          </DialogHeader>
-                          <div className="space-y-4">
-                            <div className="space-y-2">
-                              <h4 className="font-semibold">기본 정보</h4>
-                              <div className="text-sm space-y-1">
-                                <p><strong>닉네임:</strong> {user.nickname}</p>
-                                <p><strong>이메일:</strong> {user.email}</p>
-                                {user.phone && <p><strong>휴대폰:</strong> {user.phone}</p>}
-                                <p><strong>가입 유형:</strong> {user.signupType}</p>
-                                <p><strong>가입일:</strong> {new Date(user.createdAt).toLocaleDateString('ko-KR')}</p>
-                                {user.lastLoginAt && (
-                                  <p><strong>마지막 로그인:</strong> {new Date(user.lastLoginAt).toLocaleDateString('ko-KR')}</p>
-                                )}
-                              </div>
-                            </div>
-
-                            <div className="space-y-2">
-                              <h4 className="font-semibold">상태 변경</h4>
-                              <Select
-                                defaultValue={user.status}
-                                onValueChange={(value) => updateUserStatus(user.id, value as UserStatus)}
-                              >
-                                <SelectTrigger>
-                                  <SelectValue />
-                                </SelectTrigger>
-                                <SelectContent>
-                                  <SelectItem value="ACTIVE">정상</SelectItem>
-                                  <SelectItem value="SUSPENDED">정지</SelectItem>
-                                  <SelectItem value="WITHDRAWN">탈퇴</SelectItem>
-                                </SelectContent>
-                              </Select>
-                            </div>
-                          </div>
-                        </DialogContent>
-                      </Dialog>
+          {loading ? (
+            <div className="py-12 text-center text-gray-500">불러오는 중...</div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>ID</TableHead>
+                  <TableHead>이메일</TableHead>
+                  <TableHead>닉네임</TableHead>
+                  <TableHead>가입 유형</TableHead>
+                  <TableHead>상태</TableHead>
+                  <TableHead>가입일</TableHead>
+                  <TableHead>액션</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {users.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={7} className="text-center text-gray-500 py-8">
+                      회원이 없습니다
                     </TableCell>
                   </TableRow>
-                );
-              })}
-            </TableBody>
-          </Table>
+                ) : (
+                  users.map((user) => (
+                    <TableRow key={user.id}>
+                      <TableCell className="text-sm text-gray-500">#{user.id}</TableCell>
+                      <TableCell>{user.email}</TableCell>
+                      <TableCell className="font-medium">{user.nickname}</TableCell>
+                      <TableCell className="text-sm text-gray-500">{user.signupType}</TableCell>
+                      <TableCell>
+                        <Badge variant={statusLabels[user.status].variant}>
+                          {statusLabels[user.status].label}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-sm text-gray-500">
+                        {new Date(user.createdAt).toLocaleDateString("ko-KR")}
+                      </TableCell>
+                      <TableCell>
+                        <Button variant="outline" size="sm" onClick={() => openDetail(user.id)}>
+                          상세
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          )}
         </CardContent>
       </Card>
+
+      <Dialog open={dialogOpen} onOpenChange={(o) => { setDialogOpen(o); if (!o) setSelectedUser(null); }}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>회원 상세</DialogTitle>
+            <DialogDescription>회원 정보 및 상태를 관리합니다</DialogDescription>
+          </DialogHeader>
+          {selectedUser && (
+            <div className="space-y-4">
+              <div className="grid grid-cols-2 gap-3 text-sm">
+                <div><span className="text-gray-500">ID:</span> #{selectedUser.id}</div>
+                <div><span className="text-gray-500">이메일:</span> {selectedUser.email || "-"}</div>
+                <div><span className="text-gray-500">닉네임:</span> {selectedUser.nickname}</div>
+                <div><span className="text-gray-500">가입유형:</span> {selectedUser.signupType}</div>
+                <div><span className="text-gray-500">상태:</span>{" "}
+                  <Badge variant={statusLabels[selectedUser.status].variant}>
+                    {statusLabels[selectedUser.status].label}
+                  </Badge>
+                </div>
+                <div><span className="text-gray-500">가입일:</span>{" "}
+                  {new Date(selectedUser.createdAt).toLocaleDateString("ko-KR")}
+                </div>
+                <div><span className="text-gray-500">최근 로그인:</span>{" "}
+                  {selectedUser.lastLoginAt ? new Date(selectedUser.lastLoginAt).toLocaleString("ko-KR") : "-"}
+                </div>
+              </div>
+              <div className="flex gap-2 pt-2">
+                {selectedUser.status !== "ACTIVE" && (
+                  <Button size="sm" onClick={() => updateStatus(selectedUser.id, "ACTIVE")}>정상 전환</Button>
+                )}
+                {selectedUser.status !== "SUSPENDED" && selectedUser.status !== "WITHDRAWN" && (
+                  <Button size="sm" variant="destructive" onClick={() => updateStatus(selectedUser.id, "SUSPENDED")}>정지</Button>
+                )}
+                {selectedUser.status !== "WITHDRAWN" && (
+                  <Button size="sm" variant="outline" onClick={() => updateStatus(selectedUser.id, "WITHDRAWN")}>탈퇴 처리</Button>
+                )}
+              </div>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/front/src/pages/user/NoticeDetail.tsx
+++ b/front/src/pages/user/NoticeDetail.tsx
@@ -1,23 +1,56 @@
+import { useCallback, useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router";
 import { ArrowLeft, Eye, Pin } from "lucide-react";
 import { Button } from "../../components/ui/button";
 import { Badge } from "../../components/ui/badge";
 import { Card, CardContent } from "../../components/ui/card";
 import { Separator } from "../../components/ui/separator";
-import { mockNotices } from "../../data/mockData";
+import { api } from "../../utils/api";
+import { unwrap } from "../../utils/exception";
+import type { Notice } from "../../types";
 
 export default function NoticeDetail() {
   const { id } = useParams();
   const navigate = useNavigate();
-  const notice = mockNotices.find(n => n.id === Number(id));
+  const [notice, setNotice] = useState<Notice | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(() => {
+    if (!id || Number.isNaN(Number(id))) {
+      setNotice(null);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    api
+      .get<Notice>(`/v1/notices/${id}`)
+      .then((res) => setNotice(unwrap(res)))
+      .catch(() => setNotice(null))
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  if (loading) {
+    return (
+      <div className="text-center py-12 text-gray-500">불러오는 중...</div>
+    );
+  }
 
   if (!notice) {
     return (
       <div className="text-center py-12">
         <p className="text-gray-500">공지사항을 찾을 수 없습니다</p>
+        <Button variant="outline" className="mt-4" onClick={() => navigate("/notice")}>
+          목록으로
+        </Button>
       </div>
     );
   }
+
+  const dateRaw = notice.publishedAt ?? notice.createdAt;
 
   return (
     <div className="max-w-4xl mx-auto">
@@ -32,7 +65,6 @@ export default function NoticeDetail() {
 
       <Card>
         <CardContent className="p-8">
-          {/* Header */}
           <div className="mb-6">
             <div className="flex items-center space-x-2 mb-3">
               {notice.isPinned && (
@@ -42,19 +74,19 @@ export default function NoticeDetail() {
                 </>
               )}
             </div>
-            
+
             <h1 className="text-3xl font-bold text-gray-900 mb-4">
               {notice.title}
             </h1>
 
             <div className="flex items-center space-x-4 text-sm text-gray-500">
               <span>
-                {new Date(notice.publishedAt!).toLocaleDateString('ko-KR', {
-                  year: 'numeric',
-                  month: 'long',
-                  day: 'numeric',
-                  hour: '2-digit',
-                  minute: '2-digit'
+                {new Date(dateRaw).toLocaleDateString("ko-KR", {
+                  year: "numeric",
+                  month: "long",
+                  day: "numeric",
+                  hour: "2-digit",
+                  minute: "2-digit",
                 })}
               </span>
               <div className="flex items-center">
@@ -66,17 +98,14 @@ export default function NoticeDetail() {
 
           <Separator className="my-6" />
 
-          {/* Content */}
-          <div 
-            className="prose max-w-none"
-            dangerouslySetInnerHTML={{ __html: notice.content }}
-          />
+          <div className="whitespace-pre-wrap text-gray-800 leading-relaxed">
+            {notice.content}
+          </div>
         </CardContent>
       </Card>
 
-      {/* Navigation */}
       <div className="mt-6 flex justify-between">
-        <Button variant="outline" onClick={() => navigate(-1)}>
+        <Button variant="outline" onClick={() => navigate("/notice")}>
           목록으로
         </Button>
       </div>

--- a/front/src/pages/user/NoticeList.tsx
+++ b/front/src/pages/user/NoticeList.tsx
@@ -1,12 +1,59 @@
+import { useCallback, useEffect, useState } from "react";
 import { Link } from "react-router";
 import { Eye, Pin } from "lucide-react";
 import { Badge } from "../../components/ui/badge";
 import { Card, CardContent } from "../../components/ui/card";
-import { mockNotices } from "../../data/mockData";
+import { api } from "../../utils/api";
+import { unwrap } from "../../utils/exception";
+import type { Notice, PageResponse } from "../../types";
 
 export default function NoticeList() {
-  const pinnedNotices = mockNotices.filter(n => n.isPinned && n.status === 'PUBLISHED');
-  const regularNotices = mockNotices.filter(n => !n.isPinned && n.status === 'PUBLISHED');
+  const [notices, setNotices] = useState<Notice[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  const load = useCallback(() => {
+    setLoading(true);
+    setError(false);
+    api
+      .get<PageResponse<Notice>>("/v1/notices?page=0&size=100")
+      .then((res) => setNotices(unwrap(res).content))
+      .catch(() => {
+        setError(true);
+        setNotices([]);
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const pinnedNotices = notices.filter((n) => n.isPinned);
+  const regularNotices = notices.filter((n) => !n.isPinned);
+
+  const formatDate = (n: Notice) => {
+    const raw = n.publishedAt ?? n.createdAt;
+    return new Date(raw).toLocaleDateString("ko-KR", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+  };
+
+  if (loading) {
+    return (
+      <div className="py-12 text-center text-gray-500">불러오는 중...</div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="py-12 text-center text-red-600">
+        공지사항을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.
+      </div>
+    );
+  }
 
   return (
     <div>
@@ -16,7 +63,6 @@ export default function NoticeList() {
       </div>
 
       <div className="space-y-3">
-        {/* Pinned Notices */}
         {pinnedNotices.map((notice) => (
           <Link key={notice.id} to={`/notice/${notice.id}`}>
             <Card className="hover:shadow-lg transition-shadow cursor-pointer border-2 border-yellow-200 bg-yellow-50">
@@ -31,13 +77,7 @@ export default function NoticeList() {
                       {notice.title}
                     </h3>
                     <div className="flex items-center space-x-4 text-sm text-gray-500">
-                      <span>
-                        {new Date(notice.publishedAt!).toLocaleDateString('ko-KR', {
-                          year: 'numeric',
-                          month: 'long',
-                          day: 'numeric'
-                        })}
-                      </span>
+                      <span>{formatDate(notice)}</span>
                       <div className="flex items-center">
                         <Eye className="w-4 h-4 mr-1" />
                         {notice.viewCount.toLocaleString()}
@@ -50,7 +90,6 @@ export default function NoticeList() {
           </Link>
         ))}
 
-        {/* Regular Notices */}
         {regularNotices.map((notice) => (
           <Link key={notice.id} to={`/notice/${notice.id}`}>
             <Card className="hover:shadow-lg transition-shadow cursor-pointer">
@@ -61,13 +100,7 @@ export default function NoticeList() {
                       {notice.title}
                     </h3>
                     <div className="flex items-center space-x-4 text-sm text-gray-500">
-                      <span>
-                        {new Date(notice.publishedAt!).toLocaleDateString('ko-KR', {
-                          year: 'numeric',
-                          month: 'long',
-                          day: 'numeric'
-                        })}
-                      </span>
+                      <span>{formatDate(notice)}</span>
                       <div className="flex items-center">
                         <Eye className="w-4 h-4 mr-1" />
                         {notice.viewCount.toLocaleString()}
@@ -81,7 +114,7 @@ export default function NoticeList() {
         ))}
       </div>
 
-      {mockNotices.filter(n => n.status === 'PUBLISHED').length === 0 && (
+      {notices.length === 0 && (
         <Card className="p-12">
           <div className="text-center">
             <div className="w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">

--- a/front/src/routes.ts
+++ b/front/src/routes.ts
@@ -22,6 +22,7 @@ import AdminInquiries from "./pages/admin/AdminInquiries";
 import AdminNotices from "./pages/admin/AdminNotices";
 import AdminExchangeRate from "./pages/admin/AdminExchangeRate";
 import AdminUsers from "./pages/admin/AdminUsers";
+import AdminAdmins from "./pages/admin/AdminAdmins";
 import NotFound from "./pages/NotFound";
 import ExamplePage from "./pages/ExamplePage";
 
@@ -59,6 +60,7 @@ export const router = createBrowserRouter([
           { path: "notices", Component: AdminNotices },
           { path: "exchange-rate", Component: AdminExchangeRate },
           { path: "users", Component: AdminUsers },
+          { path: "admins", Component: AdminAdmins },
         ],
       },
       { path: "*", Component: NotFound },

--- a/front/src/types/domain.ts
+++ b/front/src/types/domain.ts
@@ -116,6 +116,10 @@ export interface InquiryListItem {
   createdAt: string;
 }
 
+export interface AdminInquiryListItem extends InquiryListItem {
+  userId: number;
+}
+
 export interface InquiryReply {
   id: number;
   inquiryId: number;
@@ -124,6 +128,14 @@ export interface InquiryReply {
   isRead: boolean;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface ReplyTemplate {
+  id: number;
+  title: string;
+  content: string;
+  category: InquiryCategory | null;
+  sortOrder: number;
 }
 
 export type NoticeStatus = 'DRAFT' | 'SCHEDULED' | 'PUBLISHED' | 'HIDDEN';
@@ -137,6 +149,7 @@ export interface Notice {
   viewCount: number;
   status: NoticeStatus;
   publishedAt?: string;
+  scheduledAt?: string;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
### 변경 사항

- 관리자 **대시보드** 상단 통계 카드(전체 회원 / 1:1 문의 / 공지사항) 클릭 시 **같은 탭**에서 `Dialog`로 상세 표시
- **회원** 팝업: `/v1/admin/users/stats`, `/v1/admin/users` 연동, 통계 요약·최근 회원 테이블, 상태 변경(정상/정지), 「전체 보기」→ 회원 관리 페이지
- **문의** 팝업: `/v1/admin/inquiries` 목록·상세·답변 등록, 「전체 보기」→ 문의 관리 페이지
- **공지** 팝업: `/v1/admin/notices` 목록, 고정 토글·삭제, 「전체 보기」→ 공지 관리 페이지
- **환율** 카드: 팝업 없이 `/admin/exchange-rate`로 이동
- **최근 문의** 행 클릭 시 문의 팝업에서 해당 건 상세로 바로 진입
- 팝업에서 저장/삭제 후 대시보드 통계·목록 **재조회**로 반영

### 테스트

- [O] 로컬에서 테스트 완료  
- [O] 관련 기능 수동 테스트 완료  

### 체크리스트

- [O] 컨벤션에 맞게 커밋/브랜치 이름 작성  
- [O] 불필요한 로그/주석 제거  
- [O] 문서(README/주석) 업데이트 필요 시 반영 *(이번 변경은 README 미수정 시 “해당 없음”으로 간주)*  

### 관련 이슈/티켓

- REQ-007
- REQ-ETC-002

---