### PR TITLE
[feat] REQ-001 이메일 인증 후 회원가입,로그인,마이페이지 연동, 비밀번호 변경/찾기, 로그아웃

### DIFF
--- a/back/src/main/java/com/ruxpress/common/util/JwtUtil.java
+++ b/back/src/main/java/com/ruxpress/common/util/JwtUtil.java
@@ -47,4 +47,32 @@ public class JwtUtil {
         String sub = parseToken(token).getSubject();
         return sub == null ? null : Long.parseLong(sub);
     }
+
+    /**
+     * {@code Authorization: Bearer …} 에서 일반 회원 JWT만 해석해 userId를 반환한다.
+     * 관리자 JWT({@code role} 클레임 존재)는 {@code null}.
+     */
+    public Long resolveUserIdFromAuthorizationHeader(String authorizationHeader) {
+        if (authorizationHeader == null) {
+            return null;
+        }
+        String[] parts = authorizationHeader.trim().split("\\s+", 2);
+        if (parts.length != 2 || !parts[0].equalsIgnoreCase("Bearer")) {
+            return null;
+        }
+        String token = parts[1].trim();
+        if (token.isEmpty()) {
+            return null;
+        }
+        try {
+            Claims c = parseToken(token);
+            if (c.get("role") != null) {
+                return null;
+            }
+            String sub = c.getSubject();
+            return sub == null ? null : Long.parseLong(sub);
+        } catch (Exception e) {
+            return null;
+        }
+    }
 }

--- a/back/src/main/java/com/ruxpress/domain/user/controller/UserController.java
+++ b/back/src/main/java/com/ruxpress/domain/user/controller/UserController.java
@@ -1,15 +1,24 @@
 package com.ruxpress.domain.user.controller;
 
 import com.ruxpress.common.dto.ApiResponse;
+import com.ruxpress.common.exception.BusinessException;
+import com.ruxpress.common.exception.ErrorCode;
+import com.ruxpress.common.util.JwtUtil;
+import com.ruxpress.domain.user.dto.ChangePasswordRequest;
 import com.ruxpress.domain.user.dto.EmailSignupRequest;
 import com.ruxpress.domain.user.dto.EmailVerificationRequest;
 import com.ruxpress.domain.user.dto.EmailVerifyRequest;
+import com.ruxpress.domain.user.dto.ForgotPasswordRequest;
 import com.ruxpress.domain.user.dto.LoginRequest;
 import com.ruxpress.domain.user.dto.LoginResponse;
+import com.ruxpress.domain.user.dto.ResetPasswordRequest;
+import com.ruxpress.domain.user.dto.response.UserResponse;
 import com.ruxpress.domain.user.service.EmailVerificationService;
+import com.ruxpress.domain.user.service.PasswordResetService;
 import com.ruxpress.domain.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -19,6 +28,8 @@ public class UserController {
 
     private final EmailVerificationService emailVerificationService;
     private final UserService userService;
+    private final PasswordResetService passwordResetService;
+    private final JwtUtil jwtUtil;
 
     /**
      * 이메일 인증 코드 발송 (실제 메일 발송)
@@ -48,11 +59,57 @@ public class UserController {
     }
 
     /**
+     * 현재 로그인한 회원 정보 (Bearer: 일반 회원 JWT)
+     */
+    @GetMapping("/me")
+    public ApiResponse<UserResponse> me(@RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorization) {
+        Long userId = jwtUtil.resolveUserIdFromAuthorizationHeader(authorization);
+        if (userId == null) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED, "로그인이 필요합니다.");
+        }
+        UserResponse profile = userService.getProfileForCurrentUser(userId);
+        return ApiResponse.success(profile);
+    }
+
+    /**
+     * 비밀번호 변경 (로그인 상태, 현재 비밀번호 확인)
+     */
+    @PostMapping("/me/password")
+    public ApiResponse<Void> changePassword(
+            @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorization,
+            @Valid @RequestBody ChangePasswordRequest request) {
+        Long userId = jwtUtil.resolveUserIdFromAuthorizationHeader(authorization);
+        if (userId == null) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED, "로그인이 필요합니다.");
+        }
+        userService.changePassword(userId, request);
+        return ApiResponse.success("비밀번호가 변경되었습니다.", null);
+    }
+
+    /**
      * 이메일/비밀번호 로그인. 성공 시 JWT 및 사용자 정보 반환.
      */
     @PostMapping("/login")
     public ApiResponse<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
         LoginResponse response = userService.login(request);
         return ApiResponse.success("로그인되었습니다.", response);
+    }
+
+    /**
+     * 비밀번호 찾기: 등록된 이메일이면 재설정 링크 발송(항상 동일 메시지).
+     */
+    @PostMapping("/password/forgot")
+    public ApiResponse<Void> forgotPassword(@Valid @RequestBody ForgotPasswordRequest request) {
+        passwordResetService.requestPasswordReset(request.getEmail());
+        return ApiResponse.success("입력하신 이메일로 재설정 안내가 발송되었습니다. (메일이 없으면 스팸함을 확인해 주세요)", null);
+    }
+
+    /**
+     * 토큰으로 비밀번호 재설정
+     */
+    @PostMapping("/password/reset")
+    public ApiResponse<Void> resetPassword(@Valid @RequestBody ResetPasswordRequest request) {
+        passwordResetService.resetPassword(request.getToken(), request.getNewPassword());
+        return ApiResponse.success("비밀번호가 변경되었습니다. 로그인해 주세요.", null);
     }
 }

--- a/back/src/main/java/com/ruxpress/domain/user/dto/ChangePasswordRequest.java
+++ b/back/src/main/java/com/ruxpress/domain/user/dto/ChangePasswordRequest.java
@@ -1,0 +1,23 @@
+package com.ruxpress.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ChangePasswordRequest {
+
+    @NotBlank(message = "현재 비밀번호를 입력하세요.")
+    private String currentPassword;
+
+    @NotBlank(message = "새 비밀번호를 입력하세요.")
+    @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*(),.?\":{}|<>]).*$",
+            message = "비밀번호는 영문, 숫자, 특수문자를 포함해야 합니다.")
+    private String newPassword;
+}

--- a/back/src/main/java/com/ruxpress/domain/user/dto/EmailSignupRequest.java
+++ b/back/src/main/java/com/ruxpress/domain/user/dto/EmailSignupRequest.java
@@ -26,4 +26,16 @@ public class EmailSignupRequest {
     @NotBlank(message = "닉네임을 입력하세요.")
     @Size(min = 1, max = 50)
     private String nickname;
+
+    /** 우편번호 (선택) */
+    @Size(max = 10)
+    private String addressPostalCode;
+
+    @NotBlank(message = "주소를 입력하세요.")
+    @Size(max = 255)
+    private String addressLine1;
+
+    /** 상세주소 (선택) */
+    @Size(max = 255)
+    private String addressLine2;
 }

--- a/back/src/main/java/com/ruxpress/domain/user/dto/ForgotPasswordRequest.java
+++ b/back/src/main/java/com/ruxpress/domain/user/dto/ForgotPasswordRequest.java
@@ -1,0 +1,17 @@
+package com.ruxpress.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ForgotPasswordRequest {
+
+    @NotBlank(message = "이메일을 입력하세요.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+}

--- a/back/src/main/java/com/ruxpress/domain/user/dto/ResetPasswordRequest.java
+++ b/back/src/main/java/com/ruxpress/domain/user/dto/ResetPasswordRequest.java
@@ -1,0 +1,23 @@
+package com.ruxpress.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ResetPasswordRequest {
+
+    @NotBlank(message = "재설정 링크가 올바르지 않습니다.")
+    private String token;
+
+    @NotBlank(message = "비밀번호를 입력하세요.")
+    @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*(),.?\":{}|<>]).*$",
+            message = "비밀번호는 영문, 숫자, 특수문자를 포함해야 합니다.")
+    private String newPassword;
+}

--- a/back/src/main/java/com/ruxpress/domain/user/dto/response/UserResponse.java
+++ b/back/src/main/java/com/ruxpress/domain/user/dto/response/UserResponse.java
@@ -22,6 +22,9 @@ public class UserResponse {
     private final boolean phoneVerified;
     private final SignupType signupType;
     private final String timezone;
+    private final String addressPostalCode;
+    private final String addressLine1;
+    private final String addressLine2;
     private final LocalDateTime lastLoginAt;
     private final LocalDateTime withdrawnAt;
     private final LocalDateTime createdAt;
@@ -39,6 +42,9 @@ public class UserResponse {
                 user.isPhoneVerified(),
                 user.getSignupType(),
                 user.getTimezone(),
+                user.getAddressPostalCode(),
+                user.getAddressLine1(),
+                user.getAddressLine2(),
                 user.getLastLoginAt(),
                 user.getWithdrawnAt(),
                 user.getCreatedAt(),

--- a/back/src/main/java/com/ruxpress/domain/user/entity/User.java
+++ b/back/src/main/java/com/ruxpress/domain/user/entity/User.java
@@ -57,6 +57,14 @@ public class User {
     @Builder.Default
     private String timezone = "Asia/Seoul";
 
+    @Column(name = "address_postal_code", length = 10)
+    private String addressPostalCode;
+
+    @Column(name = "address_line1", length = 255)
+    private String addressLine1;
+
+    @Column(name = "address_line2", length = 255)
+    private String addressLine2;
 
     @Column(name = "notification_settings", columnDefinition = "JSON")
     private String notificationSettings;
@@ -118,7 +126,7 @@ public class User {
         }
     }
 
-    public void updateLastLogin() {
-        this.lastLoginAt = LocalDateTime.now();
+    public void changePasswordHash(String passwordHash) {
+        this.passwordHash = passwordHash;
     }
 }

--- a/back/src/main/java/com/ruxpress/domain/user/entity/Verification.java
+++ b/back/src/main/java/com/ruxpress/domain/user/entity/Verification.java
@@ -21,13 +21,13 @@ public class Verification {
     private Long id;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 10)
+    @Column(nullable = false, length = 32)
     private VerificationType type;
 
     @Column(nullable = false, length = 255)
     private String target;
 
-    @Column(nullable = false, length = 10)
+    @Column(nullable = false, length = 64)
     private String code;
 
     @Column(nullable = false)
@@ -52,7 +52,9 @@ public class Verification {
     }
 
     public enum VerificationType {
-        EMAIL, PHONE
+        EMAIL,
+        PHONE,
+        PASSWORD_RESET
     }
 
     public boolean isExpired() {

--- a/back/src/main/java/com/ruxpress/domain/user/repository/VerificationRepository.java
+++ b/back/src/main/java/com/ruxpress/domain/user/repository/VerificationRepository.java
@@ -10,4 +10,9 @@ public interface VerificationRepository extends JpaRepository<Verification, Long
 
     Optional<Verification> findTopByTypeAndTargetAndIsVerifiedOrderByCreatedAtDesc(
             Verification.VerificationType type, String target, Boolean isVerified);
+
+    Optional<Verification> findTopByTypeAndCodeAndIsVerifiedOrderByCreatedAtDesc(
+            Verification.VerificationType type, String code, Boolean isVerified);
+
+    void deleteByTypeAndTarget(Verification.VerificationType type, String target);
 }

--- a/back/src/main/java/com/ruxpress/domain/user/service/EmailService.java
+++ b/back/src/main/java/com/ruxpress/domain/user/service/EmailService.java
@@ -22,6 +22,9 @@ public class EmailService {
     @Value("${app.mail.verification.subject:Ruxpress 이메일 인증}")
     private String subject;
 
+    @Value("${app.mail.password-reset.subject:Ruxpress 비밀번호 재설정}")
+    private String passwordResetSubject;
+
     @Value("${spring.mail.password:}")
     private String mailPassword;
 
@@ -47,6 +50,31 @@ public class EmailService {
             log.info("Verification email sent to {}", toEmail);
         } catch (Exception e) {
             log.error("Failed to send verification email to {}", toEmail, e);
+            throw new BusinessException(ErrorCode.EMAIL_SEND_FAILED, "이메일 발송에 실패했습니다.");
+        }
+    }
+
+    /**
+     * 비밀번호 재설정 링크 메일. SMTP 미설정 시 링크만 로그 출력.
+     */
+    public void sendPasswordResetLink(String toEmail, String resetUrl) {
+        if (mailPassword == null || mailPassword.trim().isBlank()) {
+            log.info("[메일 미설정] 비밀번호 재설정 링크 (실제 메일 미발송). toEmail={}, url={}", toEmail, resetUrl);
+            return;
+        }
+        String body = String.format(
+                "비밀번호를 재설정하려면 아래 링크를 클릭하세요.\n\n%s\n\n유효시간: 1시간\n\n본인이 요청한 것이 아니라면 무시하세요.",
+                resetUrl);
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom(fromAddress);
+        message.setTo(toEmail);
+        message.setSubject(passwordResetSubject);
+        message.setText(body);
+        try {
+            mailSender.send(message);
+            log.info("Password reset email sent to {}", toEmail);
+        } catch (Exception e) {
+            log.error("Failed to send password reset email to {}", toEmail, e);
             throw new BusinessException(ErrorCode.EMAIL_SEND_FAILED, "이메일 발송에 실패했습니다.");
         }
     }

--- a/back/src/main/java/com/ruxpress/domain/user/service/PasswordResetService.java
+++ b/back/src/main/java/com/ruxpress/domain/user/service/PasswordResetService.java
@@ -1,0 +1,108 @@
+package com.ruxpress.domain.user.service;
+
+import com.ruxpress.common.exception.BusinessException;
+import com.ruxpress.common.exception.ErrorCode;
+import com.ruxpress.domain.user.entity.User;
+import com.ruxpress.domain.user.entity.UserStatus;
+import com.ruxpress.domain.user.entity.Verification;
+import com.ruxpress.domain.user.repository.UserRepository;
+import com.ruxpress.domain.user.repository.VerificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class PasswordResetService {
+
+    private static final int RESET_LINK_VALID_HOURS = 1;
+
+    private final UserRepository userRepository;
+    private final VerificationRepository verificationRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final EmailService emailService;
+
+    @Value("${app.frontend.base-url:http://localhost}")
+    private String frontendBaseUrl;
+
+    /**
+     * 가입된 이메일이면 재설정 토큰 메일 발송. 없어도 동일한 성공 응답(이메일 노출 방지).
+     */
+    @Transactional
+    public void requestPasswordReset(String email) {
+        String normalized = email == null ? null : email.trim().toLowerCase();
+        if (normalized == null || normalized.isEmpty()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT, "이메일을 입력하세요.");
+        }
+        if (!normalized.matches("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$")) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT, "올바른 이메일 형식이 아닙니다.");
+        }
+
+        userRepository.findByEmail(normalized).ifPresent(user -> {
+            if (user.getStatus() != UserStatus.ACTIVE) {
+                return;
+            }
+            if (user.getPasswordHash() == null || user.getPasswordHash().isBlank()) {
+                return;
+            }
+            verificationRepository.deleteByTypeAndTarget(Verification.VerificationType.PASSWORD_RESET, normalized);
+
+            String token = UUID.randomUUID().toString();
+            LocalDateTime expiresAt = LocalDateTime.now().plusHours(RESET_LINK_VALID_HOURS);
+            Verification row = Verification.builder()
+                    .type(Verification.VerificationType.PASSWORD_RESET)
+                    .target(normalized)
+                    .code(token)
+                    .isVerified(false)
+                    .attemptCount(0)
+                    .expiresAt(expiresAt)
+                    .createdAt(LocalDateTime.now())
+                    .build();
+            verificationRepository.save(row);
+
+            String base = frontendBaseUrl.endsWith("/")
+                    ? frontendBaseUrl.substring(0, frontendBaseUrl.length() - 1)
+                    : frontendBaseUrl;
+            String resetUrl = base + "/reset-password?token=" + token;
+            emailService.sendPasswordResetLink(normalized, resetUrl);
+        });
+    }
+
+    /**
+     * 토큰으로 비밀번호 변경. 성공 시 토큰은 사용 완료 처리.
+     */
+    @Transactional
+    public void resetPassword(String token, String newPassword) {
+        String trimmedToken = token == null ? null : token.trim();
+        if (trimmedToken == null || trimmedToken.isEmpty()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT, "재설정 링크가 올바르지 않습니다.");
+        }
+
+        Verification verification = verificationRepository
+                .findTopByTypeAndCodeAndIsVerifiedOrderByCreatedAtDesc(
+                        Verification.VerificationType.PASSWORD_RESET, trimmedToken, false)
+                .orElseThrow(() -> new BusinessException(ErrorCode.VERIFICATION_NOT_FOUND,
+                        "유효하지 않거나 이미 사용된 재설정 링크입니다."));
+
+        if (verification.isExpired()) {
+            throw new BusinessException(ErrorCode.VERIFICATION_EXPIRED, "재설정 링크가 만료되었습니다. 다시 요청해 주세요.");
+        }
+
+        User user = userRepository.findByEmail(verification.getTarget())
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "회원 정보를 찾을 수 없습니다."));
+        if (user.getStatus() != UserStatus.ACTIVE) {
+            throw new BusinessException(ErrorCode.FORBIDDEN, "계정이 비활성화되었습니다.");
+        }
+
+        user.changePasswordHash(passwordEncoder.encode(newPassword));
+        userRepository.save(user);
+
+        verification.markVerified();
+        verificationRepository.save(verification);
+    }
+}

--- a/back/src/main/java/com/ruxpress/domain/user/service/UserService.java
+++ b/back/src/main/java/com/ruxpress/domain/user/service/UserService.java
@@ -15,6 +15,7 @@ import com.ruxpress.common.exception.ErrorCode;
 import com.ruxpress.common.util.JwtUtil;
 
 // Domain - User (DTO)
+import com.ruxpress.domain.user.dto.ChangePasswordRequest;
 import com.ruxpress.domain.user.dto.EmailSignupRequest;
 import com.ruxpress.domain.user.dto.LoginRequest;
 import com.ruxpress.domain.user.dto.LoginResponse;
@@ -78,6 +79,20 @@ public class UserService {
         return UserResponse.from(user);
     }
 
+    /**
+     * 로그인한 회원 본인 프로필 (삭제·비활성 계정 제외).
+     */
+    @Transactional(readOnly = true)
+    public UserResponse getProfileForCurrentUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .filter(u -> u.getDeletedAt() == null)
+                .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED, "회원 정보를 찾을 수 없습니다."));
+        if (user.getStatus() != UserStatus.ACTIVE) {
+            throw new BusinessException(ErrorCode.FORBIDDEN, "이용할 수 없는 계정입니다.");
+        }
+        return UserResponse.from(user);
+    }
+
     @Transactional
     public UserResponse changeUserStatus(Long id, UserStatus newStatus) {
         User user = userRepository.findById(id)
@@ -129,6 +144,13 @@ public class UserService {
             throw new BusinessException(ErrorCode.INVALID_INPUT, "닉네임을 입력하세요.");
         }
 
+        String line1 = request.getAddressLine1() == null ? null : request.getAddressLine1().trim();
+        if (line1 == null || line1.isEmpty()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT, "주소를 입력하세요.");
+        }
+        String postal = request.getAddressPostalCode() == null ? null : request.getAddressPostalCode().trim();
+        String line2 = request.getAddressLine2() == null ? null : request.getAddressLine2().trim();
+
         String encodedPassword = passwordEncoder.encode(request.getPassword());
         LocalDateTime now = LocalDateTime.now();
 
@@ -136,6 +158,9 @@ public class UserService {
                 .email(email)
                 .passwordHash(encodedPassword)
                 .nickname(nickname)
+                .addressPostalCode(postal == null || postal.isEmpty() ? null : postal)
+                .addressLine1(line1)
+                .addressLine2(line2 == null || line2.isEmpty() ? null : line2)
                 .status(UserStatus.ACTIVE)
                 .emailVerified(true)
                 .phoneVerified(false)
@@ -175,5 +200,26 @@ public class UserService {
 
         String token = jwtUtil.generateToken(user.getId(), user.getEmail());
         return new LoginResponse(token, user.getId(), user.getEmail(), user.getNickname());
+    }
+
+    /**
+     * 로그인한 회원의 비밀번호 변경 (현재 비밀번호 확인).
+     */
+    @Transactional
+    public void changePassword(Long userId, ChangePasswordRequest request) {
+        User user = userRepository.findById(userId)
+                .filter(u -> u.getDeletedAt() == null)
+                .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED, "회원 정보를 찾을 수 없습니다."));
+        if (user.getStatus() != UserStatus.ACTIVE) {
+            throw new BusinessException(ErrorCode.FORBIDDEN, "이용할 수 없는 계정입니다.");
+        }
+        if (user.getPasswordHash() == null || user.getPasswordHash().isEmpty()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT, "비밀번호로 가입한 계정만 변경할 수 있습니다.");
+        }
+        if (!passwordEncoder.matches(request.getCurrentPassword(), user.getPasswordHash())) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED, "현재 비밀번호가 일치하지 않습니다.");
+        }
+        user.changePasswordHash(passwordEncoder.encode(request.getNewPassword()));
+        userRepository.save(user);
     }
 }

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -24,10 +24,14 @@ spring:
     encoding: UTF-8
 
 app:
+  frontend:
+    base-url: ${FRONTEND_BASE_URL:http://localhost}
   mail:
     from: ${MAIL_FROM:}
     verification:
       subject: ${MAIL_VERIFICATION_SUBJECT:}
+    password-reset:
+      subject: ${MAIL_PASSWORD_RESET_SUBJECT:Ruxpress 비밀번호 재설정}
   jwt:
     secret: ${JWT_SECRET:}
     expiration: ${JWT_EXPIRATION:}

--- a/front/src/components/layouts/UserLayout.tsx
+++ b/front/src/components/layouts/UserLayout.tsx
@@ -11,7 +11,7 @@ import {
   SheetTrigger,
 } from "../ui/sheet";
 import { useTranslation } from "../../hooks/useTranslation";
-import { LOCALES, STORAGE_KEYS } from "../../utils/constants";
+import { LOCALES, STORAGE_KEYS, USER_AUTH_CHANGE_EVENT } from "../../utils/constants";
 
 export default function UserLayout() {
   const location = useLocation();
@@ -19,6 +19,20 @@ export default function UserLayout() {
   const { t, locale, setLocale } = useTranslation();
   const [langOpen, setLangOpen] = useState(false);
   const langRef = useRef<HTMLDivElement>(null);
+  const [, setAuthRevision] = useState(0);
+
+  useEffect(() => {
+    const syncAuth = () => setAuthRevision((n) => n + 1);
+    window.addEventListener(USER_AUTH_CHANGE_EVENT, syncAuth);
+    return () => window.removeEventListener(USER_AUTH_CHANGE_EVENT, syncAuth);
+  }, []);
+
+  useEffect(() => {
+    setAuthRevision((n) => n + 1);
+  }, [location.pathname]);
+
+  const userToken = localStorage.getItem(STORAGE_KEYS.TOKEN);
+  const userNickname = localStorage.getItem(STORAGE_KEYS.USER_NICKNAME);
 
   useEffect(() => {
     if (!langOpen) return;
@@ -117,14 +131,27 @@ export default function UserLayout() {
                   3
                 </Badge>
               </Button>
-              <Link to="/mypage">
-                <Button variant="ghost" size="icon">
-                  <User className="w-5 h-5" />
-                </Button>
-              </Link>
-              <Button variant="ghost" size="icon" onClick={handleLogout} title={t("nav.admin.logout")}>
-                <LogOut className="w-5 h-5" />
-              </Button>
+              {userToken ? (
+                <div className="flex items-center gap-1 max-w-[11rem]">
+                  <span className="hidden sm:inline text-sm text-gray-700 truncate" title={userNickname ?? ""}>
+                    {userNickname ?? "회원"}
+                  </span>
+                  <Link to="/mypage">
+                    <Button variant="ghost" size="icon" title="마이페이지">
+                      <User className="w-5 h-5" />
+                    </Button>
+                  </Link>
+                  <Button variant="ghost" size="icon" onClick={handleLogout} title={t("nav.admin.logout")}>
+                    <LogOut className="w-5 h-5" />
+                  </Button>
+                </div>
+              ) : (
+                <Link to="/login">
+                  <Button variant="ghost" size="sm" className="text-blue-600">
+                    로그인
+                  </Button>
+                </Link>
+              )}
 
               <Sheet>
                 <SheetTrigger asChild className="md:hidden">

--- a/front/src/pages/user/ForgotPassword.tsx
+++ b/front/src/pages/user/ForgotPassword.tsx
@@ -1,0 +1,71 @@
+import { useState } from "react";
+import { Link } from "react-router";
+import { Button } from "../../components/ui/button";
+import { Input } from "../../components/ui/input";
+import { Label } from "../../components/ui/label";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../components/ui/card";
+import { toast } from "sonner";
+import { api } from "../../utils/api";
+
+export default function ForgotPassword() {
+  const [email, setEmail] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = email.trim();
+    if (!trimmed) {
+      toast.error("이메일을 입력하세요");
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await api.post<unknown>("/v1/users/password/forgot", { email: trimmed });
+      if (res.code === 200) {
+        toast.success(res.message ?? "안내 메일을 확인해 주세요");
+      } else {
+        toast.error(res.message ?? "요청에 실패했습니다");
+      }
+    } catch {
+      toast.error("요청에 실패했습니다");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-[80vh] flex items-center justify-center px-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="space-y-1">
+          <CardTitle className="text-2xl text-center">비밀번호 찾기</CardTitle>
+          <CardDescription className="text-center">
+            가입 시 사용한 이메일을 입력하시면 재설정 링크를 보내드립니다.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="forgot-email">이메일</Label>
+              <Input
+                id="forgot-email"
+                type="email"
+                autoComplete="email"
+                placeholder="email@example.com"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+              />
+            </div>
+            <Button type="submit" className="w-full" size="lg" disabled={loading}>
+              {loading ? "전송 중..." : "재설정 링크 보내기"}
+            </Button>
+            <div className="text-center text-sm text-gray-600">
+              <Link to="/login" className="text-blue-600 hover:underline font-medium">
+                로그인으로 돌아가기
+              </Link>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/front/src/pages/user/Login.tsx
+++ b/front/src/pages/user/Login.tsx
@@ -4,9 +4,8 @@ import { Button } from "../../components/ui/button";
 import { Input } from "../../components/ui/input";
 import { Label } from "../../components/ui/label";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../components/ui/card";
-import { Separator } from "../../components/ui/separator";
 import { toast } from "sonner";
-import { api } from "../../utils/api";
+import { api, notifyUserAuthChange } from "../../utils/api";
 import { STORAGE_KEYS } from "../../utils/constants";
 
 interface LoginResponse {
@@ -24,7 +23,6 @@ export default function Login() {
 
   const handleLogin = async (e?: React.MouseEvent) => {
     e?.preventDefault();
-    console.log("[Login] 로그인 클릭됨", { email: email?.slice(0, 5) + "...", hasPassword: !!password });
     const trimmedEmail = email.trim();
     if (!trimmedEmail) {
       toast.error("이메일을 입력하세요");
@@ -35,22 +33,23 @@ export default function Login() {
       return;
     }
     setLoading(true);
-    console.log("[Login] API 호출 시작");
     try {
       const res = await api.post<LoginResponse>("/v1/users/login", {
         email: trimmedEmail,
         password,
       });
-      console.log("[Login] API 응답", res);
       if (res.code === 200 && res.data?.token) {
         localStorage.setItem(STORAGE_KEYS.TOKEN, res.data.token);
+        localStorage.setItem(STORAGE_KEYS.USER_ID, String(res.data.userId));
+        localStorage.setItem(STORAGE_KEYS.USER_EMAIL, res.data.email);
+        localStorage.setItem(STORAGE_KEYS.USER_NICKNAME, res.data.nickname);
+        notifyUserAuthChange();
         toast.success(res.message ?? "로그인되었습니다");
         navigate("/");
       } else {
         toast.error(res.message ?? "로그인에 실패했습니다");
       }
-    } catch (err) {
-      console.error("[Login] 로그인 실패", err);
+    } catch {
       toast.error("로그인에 실패했습니다");
     } finally {
       setLoading(false);
@@ -85,8 +84,8 @@ export default function Login() {
           <div className="space-y-2">
             <div className="flex items-center justify-between">
               <Label htmlFor="password">비밀번호</Label>
-              <Button variant="link" className="px-0 h-auto text-sm">
-                비밀번호 찾기
+              <Button variant="link" className="px-0 h-auto text-sm" asChild>
+                <Link to="/forgot-password">비밀번호 찾기</Link>
               </Button>
             </div>
             <Input
@@ -99,37 +98,6 @@ export default function Login() {
           </div>
           <Button type="button" className="w-full" size="lg" onClick={handleLogin} disabled={loading}>
             {loading ? "로그인 중..." : "로그인"}
-          </Button>
-
-          <div className="relative">
-            <div className="absolute inset-0 flex items-center">
-              <Separator />
-            </div>
-            <div className="relative flex justify-center text-xs uppercase">
-              <span className="bg-white px-2 text-gray-500">또는</span>
-            </div>
-          </div>
-
-          <Button variant="outline" className="w-full" size="lg">
-            <svg className="w-5 h-5 mr-2" viewBox="0 0 24 24">
-              <path
-                fill="currentColor"
-                d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-              />
-              <path
-                fill="currentColor"
-                d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-              />
-              <path
-                fill="currentColor"
-                d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-              />
-              <path
-                fill="currentColor"
-                d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-              />
-            </svg>
-            Google로 계속하기
           </Button>
 
           <div className="text-center text-sm text-gray-600">

--- a/front/src/pages/user/MyPage.tsx
+++ b/front/src/pages/user/MyPage.tsx
@@ -1,25 +1,175 @@
-import { User, Bell, Shield, LogOut, Mail, Phone } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router";
+import { User, Bell, Shield, LogOut, Mail, Phone, MapPin } from "lucide-react";
 import { Button } from "../../components/ui/button";
+import { Input } from "../../components/ui/input";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../components/ui/card";
 import { Switch } from "../../components/ui/switch";
 import { Label } from "../../components/ui/label";
 import { Separator } from "../../components/ui/separator";
 import { Badge } from "../../components/ui/badge";
-import { currentUser } from "../../data/mockData";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "../../components/ui/dialog";
+import { toast } from "sonner";
+import { api, clearUserSession, notifyUserAuthChange } from "../../utils/api";
+import { STORAGE_KEYS } from "../../utils/constants";
+import type { User as UserProfile } from "../../types/domain";
+
+function formatDateKo(iso: string | undefined): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleDateString("ko-KR", { year: "numeric", month: "long", day: "numeric" });
+}
+
+function formatDateTimeKo(iso: string | undefined): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleString("ko-KR", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function signupTypeLabel(t: UserProfile["signupType"]): string {
+  if (t === "EMAIL") return "이메일 가입";
+  if (t === "PHONE") return "휴대폰 가입";
+  return "Google 가입";
+}
 
 export default function MyPage() {
+  const navigate = useNavigate();
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [pwdOpen, setPwdOpen] = useState(false);
+  const [currentPwd, setCurrentPwd] = useState("");
+  const [newPwd, setNewPwd] = useState("");
+  const [newPwdConfirm, setNewPwdConfirm] = useState("");
+  const [pwdSubmitting, setPwdSubmitting] = useState(false);
+
+  const loadProfile = useCallback(async () => {
+    const token = localStorage.getItem(STORAGE_KEYS.TOKEN);
+    if (!token) {
+      toast.error("로그인이 필요합니다");
+      navigate("/login", { replace: true });
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await api.get<UserProfile>("/v1/users/me");
+      if (res.code === 200 && res.data) {
+        setProfile(res.data);
+        localStorage.setItem(STORAGE_KEYS.USER_NICKNAME, res.data.nickname);
+        localStorage.setItem(STORAGE_KEYS.USER_EMAIL, res.data.email);
+        localStorage.setItem(STORAGE_KEYS.USER_ID, String(res.data.id));
+        notifyUserAuthChange();
+      } else if (res.code === 401) {
+        clearUserSession();
+        toast.error("다시 로그인해 주세요");
+        navigate("/login", { replace: true });
+      } else {
+        toast.error(res.message ?? "프로필을 불러오지 못했습니다");
+        setProfile(null);
+      }
+    } catch {
+      toast.error("프로필을 불러오지 못했습니다");
+      setProfile(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [navigate]);
+
+  useEffect(() => {
+    void loadProfile();
+  }, [loadProfile]);
+
+  const handleLogout = () => {
+    clearUserSession();
+    toast.success("로그아웃되었습니다");
+    navigate("/login", { replace: true });
+  };
+
+  const resetPwdForm = () => {
+    setCurrentPwd("");
+    setNewPwd("");
+    setNewPwdConfirm("");
+  };
+
+  const submitPasswordChange = async () => {
+    if (!currentPwd) {
+      toast.error("현재 비밀번호를 입력하세요");
+      return;
+    }
+    if (!newPwd || newPwd.length < 8) {
+      toast.error("새 비밀번호는 8자 이상이어야 합니다");
+      return;
+    }
+    if (newPwd !== newPwdConfirm) {
+      toast.error("새 비밀번호가 일치하지 않습니다");
+      return;
+    }
+    setPwdSubmitting(true);
+    try {
+      const res = await api.post<unknown>("/v1/users/me/password", {
+        currentPassword: currentPwd,
+        newPassword: newPwd,
+      });
+      if (res.code === 200) {
+        toast.success(res.message ?? "비밀번호가 변경되었습니다");
+        setPwdOpen(false);
+        resetPwdForm();
+      } else {
+        toast.error(res.message ?? "비밀번호 변경에 실패했습니다");
+      }
+    } catch {
+      toast.error("비밀번호 변경에 실패했습니다");
+    } finally {
+      setPwdSubmitting(false);
+    }
+  };
+
+  const notif = profile?.notificationSettings;
+
+  if (loading && !profile) {
+    return (
+      <div className="max-w-4xl mx-auto">
+        <h1 className="text-3xl font-bold text-gray-900 mb-6">마이페이지</h1>
+        <p className="text-gray-600">프로필을 불러오는 중…</p>
+      </div>
+    );
+  }
+
+  if (!profile) {
+    return (
+      <div className="max-w-4xl mx-auto">
+        <h1 className="text-3xl font-bold text-gray-900 mb-6">마이페이지</h1>
+        <p className="text-gray-600 mb-4">회원 정보를 표시할 수 없습니다.</p>
+        <Button asChild variant="outline">
+          <Link to="/login">로그인</Link>
+        </Button>
+      </div>
+    );
+  }
+
   return (
     <div className="max-w-4xl mx-auto">
       <h1 className="text-3xl font-bold text-gray-900 mb-6">마이페이지</h1>
 
       <div className="space-y-6">
-        {/* Profile */}
         <Card>
           <CardHeader>
             <CardTitle>프로필 정보</CardTitle>
-            <CardDescription>
-              회원 정보를 확인하고 수정할 수 있습니다
-            </CardDescription>
+            <CardDescription>로그인한 계정 정보입니다</CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="flex items-center space-x-4">
@@ -27,78 +177,70 @@ export default function MyPage() {
                 <User className="w-10 h-10 text-white" />
               </div>
               <div className="flex-1">
-                <h3 className="text-xl font-semibold text-gray-900">
-                  {currentUser.nickname}
-                </h3>
-                <div className="flex items-center space-x-2 mt-1">
-                  <Badge variant={currentUser.status === 'ACTIVE' ? 'default' : 'outline'}>
-                    {currentUser.status === 'ACTIVE' ? '정상' : currentUser.status}
+                <h3 className="text-xl font-semibold text-gray-900">{profile.nickname}</h3>
+                <div className="flex items-center space-x-2 mt-1 flex-wrap gap-1">
+                  <Badge variant={profile.status === "ACTIVE" ? "default" : "outline"}>
+                    {profile.status === "ACTIVE" ? "정상" : profile.status}
                   </Badge>
-                  <Badge variant="outline">
-                    {currentUser.signupType === 'EMAIL' ? '이메일 가입' : 
-                     currentUser.signupType === 'PHONE' ? '휴대폰 가입' : 
-                     'Google 가입'}
-                  </Badge>
+                  <Badge variant="outline">{signupTypeLabel(profile.signupType)}</Badge>
                 </div>
               </div>
-              <Button variant="outline">프로필 수정</Button>
+              <Button type="button" variant="outline" disabled>
+                프로필 수정
+              </Button>
             </div>
 
             <Separator />
 
             <div className="space-y-3">
               <div className="flex items-center">
-                <Mail className="w-5 h-5 text-gray-400 mr-3" />
-                <div className="flex-1">
+                <Mail className="w-5 h-5 text-gray-400 mr-3 shrink-0" />
+                <div className="flex-1 min-w-0">
                   <p className="text-sm text-gray-500">이메일</p>
-                  <p className="font-medium text-gray-900">{currentUser.email}</p>
+                  <p className="font-medium text-gray-900 break-all">{profile.email}</p>
                 </div>
-                {currentUser.emailVerified && (
-                  <Badge variant="default" className="bg-green-500">인증됨</Badge>
-                )}
+                {profile.emailVerified && <Badge className="bg-green-500 shrink-0">인증됨</Badge>}
               </div>
 
-              {currentUser.phone && (
+              {profile.phone && (
                 <div className="flex items-center">
-                  <Phone className="w-5 h-5 text-gray-400 mr-3" />
+                  <Phone className="w-5 h-5 text-gray-400 mr-3 shrink-0" />
                   <div className="flex-1">
                     <p className="text-sm text-gray-500">휴대폰</p>
-                    <p className="font-medium text-gray-900">{currentUser.phone}</p>
+                    <p className="font-medium text-gray-900">{profile.phone}</p>
                   </div>
-                  {currentUser.phoneVerified && (
-                    <Badge variant="default" className="bg-green-500">인증됨</Badge>
-                  )}
+                  {profile.phoneVerified && <Badge className="bg-green-500">인증됨</Badge>}
+                </div>
+              )}
+
+              {(profile.addressLine1 || profile.addressPostalCode) && (
+                <div className="flex items-start">
+                  <MapPin className="w-5 h-5 text-gray-400 mr-3 mt-0.5 shrink-0" />
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm text-gray-500">배송지</p>
+                    <p className="font-medium text-gray-900">
+                      {[profile.addressPostalCode, profile.addressLine1, profile.addressLine2]
+                        .filter(Boolean)
+                        .join(" ")}
+                    </p>
+                  </div>
                 </div>
               )}
 
               <div className="flex items-center">
-                <User className="w-5 h-5 text-gray-400 mr-3" />
+                <User className="w-5 h-5 text-gray-400 mr-3 shrink-0" />
                 <div className="flex-1">
                   <p className="text-sm text-gray-500">가입일</p>
-                  <p className="font-medium text-gray-900">
-                    {new Date(currentUser.createdAt).toLocaleDateString('ko-KR', {
-                      year: 'numeric',
-                      month: 'long',
-                      day: 'numeric'
-                    })}
-                  </p>
+                  <p className="font-medium text-gray-900">{formatDateKo(profile.createdAt)}</p>
                 </div>
               </div>
 
-              {currentUser.lastLoginAt && (
+              {profile.lastLoginAt && (
                 <div className="flex items-center">
-                  <Shield className="w-5 h-5 text-gray-400 mr-3" />
+                  <Shield className="w-5 h-5 text-gray-400 mr-3 shrink-0" />
                   <div className="flex-1">
                     <p className="text-sm text-gray-500">마지막 로그인</p>
-                    <p className="font-medium text-gray-900">
-                      {new Date(currentUser.lastLoginAt).toLocaleDateString('ko-KR', {
-                        year: 'numeric',
-                        month: 'long',
-                        day: 'numeric',
-                        hour: '2-digit',
-                        minute: '2-digit'
-                      })}
-                    </p>
+                    <p className="font-medium text-gray-900">{formatDateTimeKo(profile.lastLoginAt)}</p>
                   </div>
                 </div>
               )}
@@ -106,19 +248,15 @@ export default function MyPage() {
           </CardContent>
         </Card>
 
-        {/* Notification Settings */}
         <Card>
           <CardHeader>
             <div className="flex items-center space-x-2">
               <Bell className="w-5 h-5 text-blue-600" />
               <CardTitle>알림 설정</CardTitle>
             </div>
-            <CardDescription>
-              받고 싶은 알림을 선택하세요
-            </CardDescription>
+            <CardDescription>알림 항목은 추후 계정과 연동될 예정입니다</CardDescription>
           </CardHeader>
           <CardContent className="space-y-6">
-            {/* Push Notifications */}
             <div>
               <h4 className="font-semibold text-gray-900 mb-3">푸시 알림</h4>
               <div className="space-y-3">
@@ -126,32 +264,31 @@ export default function MyPage() {
                   <Label htmlFor="push-inquiry" className="cursor-pointer">
                     문의 답변
                   </Label>
-                  <Switch id="push-inquiry" defaultChecked={currentUser.notificationSettings?.push.inquiryReply} />
+                  <Switch id="push-inquiry" defaultChecked={notif?.push?.inquiryReply ?? false} disabled />
                 </div>
                 <div className="flex items-center justify-between">
                   <Label htmlFor="push-notice" className="cursor-pointer">
                     공지사항
                   </Label>
-                  <Switch id="push-notice" defaultChecked={currentUser.notificationSettings?.push.notice} />
+                  <Switch id="push-notice" defaultChecked={notif?.push?.notice ?? false} disabled />
                 </div>
                 <div className="flex items-center justify-between">
                   <Label htmlFor="push-promotion" className="cursor-pointer">
                     프로모션/이벤트
                   </Label>
-                  <Switch id="push-promotion" defaultChecked={currentUser.notificationSettings?.push.promotion} />
+                  <Switch id="push-promotion" defaultChecked={notif?.push?.promotion ?? false} disabled />
                 </div>
                 <div className="flex items-center justify-between">
                   <Label htmlFor="push-purchase" className="cursor-pointer">
                     구매 상태 변경
                   </Label>
-                  <Switch id="push-purchase" defaultChecked={currentUser.notificationSettings?.push.purchaseStatus} />
+                  <Switch id="push-purchase" defaultChecked={notif?.push?.purchaseStatus ?? false} disabled />
                 </div>
               </div>
             </div>
 
             <Separator />
 
-            {/* Email Notifications */}
             <div>
               <h4 className="font-semibold text-gray-900 mb-3">이메일 알림</h4>
               <div className="space-y-3">
@@ -159,32 +296,31 @@ export default function MyPage() {
                   <Label htmlFor="email-inquiry" className="cursor-pointer">
                     문의 답변
                   </Label>
-                  <Switch id="email-inquiry" defaultChecked={currentUser.notificationSettings?.email.inquiryReply} />
+                  <Switch id="email-inquiry" defaultChecked={notif?.email?.inquiryReply ?? false} disabled />
                 </div>
                 <div className="flex items-center justify-between">
                   <Label htmlFor="email-notice" className="cursor-pointer">
                     공지사항
                   </Label>
-                  <Switch id="email-notice" defaultChecked={currentUser.notificationSettings?.email.notice} />
+                  <Switch id="email-notice" defaultChecked={notif?.email?.notice ?? false} disabled />
                 </div>
                 <div className="flex items-center justify-between">
                   <Label htmlFor="email-promotion" className="cursor-pointer">
                     프로모션/이벤트
                   </Label>
-                  <Switch id="email-promotion" defaultChecked={currentUser.notificationSettings?.email.promotion} />
+                  <Switch id="email-promotion" defaultChecked={notif?.email?.promotion ?? false} disabled />
                 </div>
                 <div className="flex items-center justify-between">
                   <Label htmlFor="email-purchase" className="cursor-pointer">
                     구매 상태 변경
                   </Label>
-                  <Switch id="email-purchase" defaultChecked={currentUser.notificationSettings?.email.purchaseStatus} />
+                  <Switch id="email-purchase" defaultChecked={notif?.email?.purchaseStatus ?? false} disabled />
                 </div>
               </div>
             </div>
 
             <Separator />
 
-            {/* SMS Notifications */}
             <div>
               <h4 className="font-semibold text-gray-900 mb-3">SMS 알림</h4>
               <div className="space-y-3">
@@ -192,51 +328,90 @@ export default function MyPage() {
                   <Label htmlFor="sms-inquiry" className="cursor-pointer">
                     문의 답변
                   </Label>
-                  <Switch id="sms-inquiry" defaultChecked={currentUser.notificationSettings?.sms.inquiryReply} />
+                  <Switch id="sms-inquiry" defaultChecked={notif?.sms?.inquiryReply ?? false} disabled />
                 </div>
                 <div className="flex items-center justify-between">
                   <Label htmlFor="sms-notice" className="cursor-pointer">
                     공지사항
                   </Label>
-                  <Switch id="sms-notice" defaultChecked={currentUser.notificationSettings?.sms.notice} />
+                  <Switch id="sms-notice" defaultChecked={notif?.sms?.notice ?? false} disabled />
                 </div>
                 <div className="flex items-center justify-between">
                   <Label htmlFor="sms-promotion" className="cursor-pointer">
                     프로모션/이벤트
                   </Label>
-                  <Switch id="sms-promotion" defaultChecked={currentUser.notificationSettings?.sms.promotion} />
+                  <Switch id="sms-promotion" defaultChecked={notif?.sms?.promotion ?? false} disabled />
                 </div>
                 <div className="flex items-center justify-between">
                   <Label htmlFor="sms-purchase" className="cursor-pointer">
                     구매 상태 변경
                   </Label>
-                  <Switch id="sms-purchase" defaultChecked={currentUser.notificationSettings?.sms.purchaseStatus} />
+                  <Switch id="sms-purchase" defaultChecked={notif?.sms?.purchaseStatus ?? false} disabled />
                 </div>
               </div>
             </div>
           </CardContent>
         </Card>
 
-        {/* Account Actions */}
         <Card>
           <CardHeader>
             <CardTitle>계정 관리</CardTitle>
           </CardHeader>
           <CardContent className="space-y-3">
-            <Button variant="outline" className="w-full justify-start">
+            <Button type="button" variant="outline" className="w-full justify-start" onClick={() => setPwdOpen(true)}>
               <Shield className="w-4 h-4 mr-2" />
               비밀번호 변경
             </Button>
-            <Button variant="outline" className="w-full justify-start text-red-600 hover:text-red-700 hover:bg-red-50">
+            <Button variant="outline" className="w-full justify-start" asChild>
+              <Link to="/forgot-password">비밀번호를 잊으셨나요? (이메일 재설정)</Link>
+            </Button>
+            <Button type="button" variant="outline" className="w-full justify-start text-red-600 hover:text-red-700 hover:bg-red-50" onClick={handleLogout}>
               <LogOut className="w-4 h-4 mr-2" />
               로그아웃
             </Button>
             <Separator />
-            <Button variant="ghost" className="w-full justify-start text-gray-500 hover:text-gray-700">
+            <Button variant="ghost" className="w-full justify-start text-gray-500 hover:text-gray-700" disabled>
               회원 탈퇴
             </Button>
           </CardContent>
         </Card>
+
+        <Dialog
+          open={pwdOpen}
+          onOpenChange={(open) => {
+            setPwdOpen(open);
+            if (!open) resetPwdForm();
+          }}
+        >
+          <DialogContent className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>비밀번호 변경</DialogTitle>
+              <DialogDescription>현재 비밀번호 확인 후 새 비밀번호를 입력하세요. (영문·숫자·특수문자 포함 8자 이상)</DialogDescription>
+            </DialogHeader>
+            <div className="space-y-3 py-2">
+              <div className="space-y-2">
+                <Label htmlFor="cur-pwd">현재 비밀번호</Label>
+                <Input id="cur-pwd" type="password" autoComplete="current-password" value={currentPwd} onChange={(e) => setCurrentPwd(e.target.value)} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="new-pwd">새 비밀번호</Label>
+                <Input id="new-pwd" type="password" autoComplete="new-password" value={newPwd} onChange={(e) => setNewPwd(e.target.value)} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="new-pwd2">새 비밀번호 확인</Label>
+                <Input id="new-pwd2" type="password" autoComplete="new-password" value={newPwdConfirm} onChange={(e) => setNewPwdConfirm(e.target.value)} />
+              </div>
+            </div>
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => setPwdOpen(false)} disabled={pwdSubmitting}>
+                취소
+              </Button>
+              <Button type="button" onClick={() => void submitPasswordChange()} disabled={pwdSubmitting}>
+                {pwdSubmitting ? "처리 중…" : "변경"}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </div>
     </div>
   );

--- a/front/src/pages/user/ResetPassword.tsx
+++ b/front/src/pages/user/ResetPassword.tsx
@@ -1,0 +1,104 @@
+import { useState } from "react";
+import { Link, useNavigate, useSearchParams } from "react-router";
+import { Button } from "../../components/ui/button";
+import { Input } from "../../components/ui/input";
+import { Label } from "../../components/ui/label";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../components/ui/card";
+import { toast } from "sonner";
+import { api } from "../../utils/api";
+
+export default function ResetPassword() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const tokenFromUrl = searchParams.get("token") ?? "";
+  const [password, setPassword] = useState("");
+  const [passwordConfirm, setPasswordConfirm] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const token = tokenFromUrl.trim();
+    if (!token) {
+      toast.error("유효한 재설정 링크가 아닙니다. 메일의 링크를 다시 확인해 주세요.");
+      return;
+    }
+    if (password.length < 8) {
+      toast.error("비밀번호는 8자 이상이어야 합니다");
+      return;
+    }
+    if (password !== passwordConfirm) {
+      toast.error("비밀번호가 일치하지 않습니다");
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await api.post<unknown>("/v1/users/password/reset", {
+        token,
+        newPassword: password,
+      });
+      if (res.code === 200) {
+        toast.success(res.message ?? "비밀번호가 변경되었습니다");
+        navigate("/login", { replace: true });
+      } else {
+        toast.error(res.message ?? "재설정에 실패했습니다");
+      }
+    } catch {
+      toast.error("재설정에 실패했습니다");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-[80vh] flex items-center justify-center px-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="space-y-1">
+          <CardTitle className="text-2xl text-center">새 비밀번호 설정</CardTitle>
+          <CardDescription className="text-center">
+            영문, 숫자, 특수문자를 포함한 8자 이상으로 입력해 주세요.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {!tokenFromUrl ? (
+            <p className="text-sm text-center text-gray-600 mb-4">
+              링크가 올바르지 않습니다. 비밀번호 찾기를 다시 진행해 주세요.
+            </p>
+          ) : null}
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="new-password">새 비밀번호</Label>
+              <Input
+                id="new-password"
+                type="password"
+                autoComplete="new-password"
+                placeholder="8자 이상 (영문, 숫자, 특수문자)"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                disabled={!tokenFromUrl}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="new-password-confirm">새 비밀번호 확인</Label>
+              <Input
+                id="new-password-confirm"
+                type="password"
+                autoComplete="new-password"
+                value={passwordConfirm}
+                onChange={(e) => setPasswordConfirm(e.target.value)}
+                disabled={!tokenFromUrl}
+              />
+            </div>
+            <Button type="submit" className="w-full" size="lg" disabled={loading || !tokenFromUrl}>
+              {loading ? "처리 중..." : "비밀번호 변경"}
+            </Button>
+            <div className="text-center text-sm text-gray-600">
+              <Link to="/login" className="text-blue-600 hover:underline font-medium">
+                로그인으로 돌아가기
+              </Link>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/front/src/pages/user/Signup.tsx
+++ b/front/src/pages/user/Signup.tsx
@@ -5,56 +5,47 @@ import { Input } from "../../components/ui/input";
 import { Label } from "../../components/ui/label";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../components/ui/card";
 import { Separator } from "../../components/ui/separator";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "../../components/ui/tabs";
 import { toast } from "sonner";
 import { api } from "../../utils/api";
 
 export default function Signup() {
   const navigate = useNavigate();
+
   const [email, setEmail] = useState("");
   const [emailVerified, setEmailVerified] = useState(false);
-  const [phoneVerified, setPhoneVerified] = useState(false);
   const [emailCode, setEmailCode] = useState("");
-  const [phoneCode, setPhoneCode] = useState("");
   const [password, setPassword] = useState("");
   const [passwordConfirm, setPasswordConfirm] = useState("");
   const [nickname, setNickname] = useState("");
+  const [addressPostalCode, setAddressPostalCode] = useState("");
+  const [addressLine1, setAddressLine1] = useState("");
+  const [addressLine2, setAddressLine2] = useState("");
   const [emailSending, setEmailSending] = useState(false);
   const [emailVerifying, setEmailVerifying] = useState(false);
   const [signupLoading, setSignupLoading] = useState(false);
 
   const sendEmailVerification = async () => {
-    console.log("[Signup] 인증 클릭됨, email:", email);
     const trimmed = email.trim();
     if (!trimmed) {
-      console.warn("[Signup] 이메일 없음, 토스트 표시");
       toast.error("이메일을 입력하세요");
       return;
     }
-    console.log("[Signup] API 호출 시작:", "/v1/users/email/send-verification", { email: trimmed });
     setEmailSending(true);
     try {
       const res = await api.post<unknown>("/v1/users/email/send-verification", { email: trimmed });
-      console.log("[Signup] API 응답:", res);
       if (res.code === 200) {
         toast.success(res.message ?? "인증 메일이 발송되었습니다");
       } else {
         toast.error(res.message ?? "발송에 실패했습니다");
       }
-    } catch (err) {
-      console.error("[Signup] 인증 메일 발송 실패:", err);
+    } catch {
       toast.error("인증 메일 발송에 실패했습니다");
     } finally {
       setEmailSending(false);
     }
   };
 
-  const sendPhoneVerification = () => {
-    toast.success("인증번호가 발송되었습니다");
-  };
-
   const verifyEmailCode = async () => {
-    console.log("[Signup] 인증번호 확인 클릭됨, email:", email, "code:", emailCode);
     const trimmedEmail = email.trim();
     if (!trimmedEmail) {
       toast.error("이메일을 입력하세요");
@@ -70,31 +61,20 @@ export default function Signup() {
         email: trimmedEmail,
         code: emailCode,
       });
-      console.log("[Signup] verify API 응답:", res);
       if (res.code === 200) {
         setEmailVerified(true);
         toast.success(res.message ?? "이메일이 인증되었습니다");
       } else {
         toast.error(res.message ?? "인증번호가 올바르지 않습니다");
       }
-    } catch (err) {
-      console.error("[Signup] 인증 확인 실패:", err);
+    } catch {
       toast.error("인증에 실패했습니다");
     } finally {
       setEmailVerifying(false);
     }
   };
 
-  const verifyPhoneCode = () => {
-    if (phoneCode === "123456") {
-      setPhoneVerified(true);
-      toast.success("휴대폰이 인증되었습니다");
-    } else {
-      toast.error("인증번호가 올바르지 않습니다");
-    }
-  };
-
-  const submitEmailSignup = async () => {
+  const submitSignup = async () => {
     const trimmedEmail = email.trim();
     if (!trimmedEmail) {
       toast.error("이메일을 입력하세요");
@@ -113,12 +93,20 @@ export default function Signup() {
       toast.error("닉네임을 입력하세요");
       return;
     }
+    const line1 = addressLine1.trim();
+    if (!line1) {
+      toast.error("주소를 입력하세요");
+      return;
+    }
     setSignupLoading(true);
     try {
       const res = await api.post<unknown>("/v1/users/signup", {
         email: trimmedEmail,
         password,
         nickname: trimmedNickname,
+        addressPostalCode: addressPostalCode.trim() || undefined,
+        addressLine1: line1,
+        addressLine2: addressLine2.trim() || undefined,
       });
       if (res.code === 200) {
         toast.success(res.message ?? "회원가입이 완료되었습니다");
@@ -134,7 +122,7 @@ export default function Signup() {
   };
 
   return (
-    <div className="min-h-[80vh] flex items-center justify-center">
+    <div className="min-h-[80vh] flex items-center justify-center px-4 py-8">
       <Card className="w-full max-w-md">
         <CardHeader className="space-y-1">
           <div className="flex items-center justify-center mb-4">
@@ -144,201 +132,120 @@ export default function Signup() {
           </div>
           <CardTitle className="text-2xl text-center">회원가입</CardTitle>
           <CardDescription className="text-center">
-            Ruxpress 계정을 만들어보세요
+            이메일 인증 후 비밀번호·닉네임·배송지 주소를 입력해 주세요
           </CardDescription>
         </CardHeader>
-        <CardContent>
-          <Tabs defaultValue="email" className="w-full">
-            <TabsList className="grid w-full grid-cols-2 mb-6">
-              <TabsTrigger value="email">이메일</TabsTrigger>
-              <TabsTrigger value="phone">휴대폰</TabsTrigger>
-            </TabsList>
-
-            {/* Email Signup */}
-            <TabsContent value="email" className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="signup-email">이메일</Label>
-                <div className="flex space-x-2">
-                  <Input
-                    id="signup-email"
-                    type="email"
-                    placeholder="email@example.com"
-                    className="flex-1"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    disabled={emailVerified}
-                  />
-                  {!emailVerified && (
-                    <Button variant="outline" onClick={sendEmailVerification} disabled={emailSending}>
-                      {emailSending ? "발송중..." : "인증"}
-                    </Button>
-                  )}
-                </div>
-              </div>
-
+        <CardContent className="space-y-4">
+          <p className="text-xs text-gray-500">
+            메일로 받은 인증번호로 이메일을 확인한 뒤 나머지 정보를 입력합니다.
+          </p>
+          <div className="space-y-2">
+            <Label htmlFor="signup-email">이메일 (아이디)</Label>
+            <div className="flex space-x-2">
+              <Input
+                id="signup-email"
+                type="email"
+                placeholder="email@example.com"
+                className="flex-1"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                disabled={emailVerified}
+              />
               {!emailVerified && (
-                <div className="space-y-2">
-                  <Label htmlFor="email-code">인증번호</Label>
-                  <div className="flex space-x-2">
-                    <Input
-                      id="email-code"
-                      placeholder="6자리 숫자"
-                      value={emailCode}
-                      onChange={(e) => setEmailCode(e.target.value)}
-                      className="flex-1"
-                    />
-                    <Button onClick={verifyEmailCode} disabled={emailVerifying}>
-                      {emailVerifying ? "확인중..." : "확인"}
-                    </Button>
-                  </div>
-                  <p className="text-xs text-gray-500">
-                    인증번호 유효시간: 10분
-                  </p>
-                </div>
+                <Button type="button" variant="outline" onClick={sendEmailVerification} disabled={emailSending}>
+                  {emailSending ? "발송중..." : "인증"}
+                </Button>
               )}
-
-              {emailVerified && (
-                <>
-                  <div className="space-y-2">
-                    <Label htmlFor="password">비밀번호</Label>
-                    <Input
-                      id="password"
-                      type="password"
-                      placeholder="8자 이상 (영문, 숫자, 특수문자)"
-                      value={password}
-                      onChange={(e) => setPassword(e.target.value)}
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="password-confirm">비밀번호 확인</Label>
-                    <Input
-                      id="password-confirm"
-                      type="password"
-                      placeholder="비밀번호 재입력"
-                      value={passwordConfirm}
-                      onChange={(e) => setPasswordConfirm(e.target.value)}
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="nickname">닉네임</Label>
-                    <Input
-                      id="nickname"
-                      placeholder="닉네임을 입력하세요"
-                      value={nickname}
-                      onChange={(e) => setNickname(e.target.value)}
-                    />
-                  </div>
-                  <Button className="w-full" size="lg" onClick={submitEmailSignup} disabled={signupLoading}>
-                    {signupLoading ? "가입 중..." : "가입하기"}
-                  </Button>
-                </>
-              )}
-            </TabsContent>
-
-            {/* Phone Signup */}
-            <TabsContent value="phone" className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="signup-phone">휴대폰 번호</Label>
-                <div className="flex space-x-2">
-                  <Input
-                    id="signup-phone"
-                    type="tel"
-                    placeholder="010-1234-5678"
-                    className="flex-1"
-                    disabled={phoneVerified}
-                  />
-                  {!phoneVerified && (
-                    <Button variant="outline" onClick={sendPhoneVerification}>
-                      인증
-                    </Button>
-                  )}
-                </div>
-              </div>
-
-              {!phoneVerified && (
-                <div className="space-y-2">
-                  <Label htmlFor="phone-code">인증번호</Label>
-                  <div className="flex space-x-2">
-                    <Input
-                      id="phone-code"
-                      placeholder="6자리 숫자"
-                      value={phoneCode}
-                      onChange={(e) => setPhoneCode(e.target.value)}
-                      className="flex-1"
-                    />
-                    <Button onClick={verifyPhoneCode}>확인</Button>
-                  </div>
-                  <p className="text-xs text-gray-500">
-                    인증번호 유효시간: 3분
-                  </p>
-                </div>
-              )}
-
-              {phoneVerified && (
-                <>
-                  <div className="space-y-2">
-                    <Label htmlFor="phone-password">비밀번호</Label>
-                    <Input
-                      id="phone-password"
-                      type="password"
-                      placeholder="8자 이상 입력"
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="phone-password-confirm">비밀번호 확인</Label>
-                    <Input
-                      id="phone-password-confirm"
-                      type="password"
-                      placeholder="비밀번호 재입력"
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="phone-nickname">닉네임</Label>
-                    <Input
-                      id="phone-nickname"
-                      placeholder="닉네임을 입력하세요"
-                    />
-                  </div>
-                  <Button className="w-full" size="lg">
-                    가입하기
-                  </Button>
-                </>
-              )}
-            </TabsContent>
-          </Tabs>
-
-          <div className="mt-6">
-            <div className="relative">
-              <div className="absolute inset-0 flex items-center">
-                <Separator />
-              </div>
-              <div className="relative flex justify-center text-xs uppercase">
-                <span className="bg-white px-2 text-gray-500">또는</span>
-              </div>
             </div>
-
-            <Button variant="outline" className="w-full mt-4" size="lg">
-              <svg className="w-5 h-5 mr-2" viewBox="0 0 24 24">
-                <path
-                  fill="currentColor"
-                  d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-                />
-                <path
-                  fill="currentColor"
-                  d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-                />
-                <path
-                  fill="currentColor"
-                  d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-                />
-                <path
-                  fill="currentColor"
-                  d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-                />
-              </svg>
-              Google로 가입하기
-            </Button>
           </div>
+
+          {!emailVerified && (
+            <div className="space-y-2">
+              <Label htmlFor="email-code">인증번호</Label>
+              <div className="flex space-x-2">
+                <Input
+                  id="email-code"
+                  placeholder="6자리 숫자"
+                  value={emailCode}
+                  onChange={(e) => setEmailCode(e.target.value)}
+                  className="flex-1"
+                />
+                <Button type="button" onClick={verifyEmailCode} disabled={emailVerifying}>
+                  {emailVerifying ? "확인중..." : "확인"}
+                </Button>
+              </div>
+              <p className="text-xs text-gray-500">인증번호 유효시간: 10분</p>
+            </div>
+          )}
+
+          {emailVerified && (
+            <>
+              <div className="space-y-2">
+                <Label htmlFor="password">비밀번호</Label>
+                <Input
+                  id="password"
+                  type="password"
+                  autoComplete="new-password"
+                  placeholder="8자 이상 (영문, 숫자, 특수문자)"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="password-confirm">비밀번호 확인</Label>
+                <Input
+                  id="password-confirm"
+                  type="password"
+                  autoComplete="new-password"
+                  placeholder="비밀번호 재입력"
+                  value={passwordConfirm}
+                  onChange={(e) => setPasswordConfirm(e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="nickname">닉네임</Label>
+                <Input
+                  id="nickname"
+                  placeholder="닉네임을 입력하세요"
+                  value={nickname}
+                  onChange={(e) => setNickname(e.target.value)}
+                />
+              </div>
+              <Separator className="my-2" />
+              <p className="text-sm font-medium text-gray-800">배송지 주소</p>
+              <div className="space-y-2">
+                <Label htmlFor="addr-postal">우편번호 (선택)</Label>
+                <Input
+                  id="addr-postal"
+                  placeholder="예: 06234"
+                  value={addressPostalCode}
+                  onChange={(e) => setAddressPostalCode(e.target.value)}
+                  maxLength={10}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="addr-line1">기본 주소</Label>
+                <Input
+                  id="addr-line1"
+                  placeholder="시·구·동, 도로명 등"
+                  value={addressLine1}
+                  onChange={(e) => setAddressLine1(e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="addr-line2">상세 주소 (선택)</Label>
+                <Input
+                  id="addr-line2"
+                  placeholder="동·호수 등"
+                  value={addressLine2}
+                  onChange={(e) => setAddressLine2(e.target.value)}
+                />
+              </div>
+              <Button type="button" className="w-full" size="lg" onClick={submitSignup} disabled={signupLoading}>
+                {signupLoading ? "가입 중..." : "가입하기"}
+              </Button>
+            </>
+          )}
 
           <div className="text-center text-sm text-gray-600 mt-6">
             이미 계정이 있으신가요?{" "}

--- a/front/src/routes.ts
+++ b/front/src/routes.ts
@@ -5,6 +5,8 @@ import AdminLayout from "./components/layouts/AdminLayout";
 import Home from "./pages/user/Home";
 import Login from "./pages/user/Login";
 import Signup from "./pages/user/Signup";
+import ForgotPassword from "./pages/user/ForgotPassword";
+import ResetPassword from "./pages/user/ResetPassword";
 import PurchaseRequestForm from "./pages/user/PurchaseRequestForm";
 import PurchaseRequestList from "./pages/user/PurchaseRequestList";
 import InquiryList from "./pages/user/InquiryList";
@@ -89,6 +91,16 @@ export const router = createBrowserRouter([
           { path: "notice", Component: NoticeList, loader: requireUserAuth },
           { path: "notice/:id", Component: NoticeDetail, loader: requireUserAuth },
           { path: "mypage", Component: MyPage, loader: requireUserAuth },
+          { path: "forgot-password", Component: ForgotPassword },
+          { path: "reset-password", Component: ResetPassword },
+          { path: "purchase/new", Component: PurchaseRequestForm },
+          { path: "purchase", Component: PurchaseRequestList },
+          { path: "inquiry", Component: InquiryList },
+          { path: "inquiry/new", Component: InquiryForm },
+          { path: "inquiry/:id", Component: InquiryDetail },
+          { path: "notice", Component: NoticeList },
+          { path: "notice/:id", Component: NoticeDetail },
+          { path: "mypage", Component: MyPage },
           { path: "example1", Component: ExamplePage },
         ],
       },

--- a/front/src/types/domain.ts
+++ b/front/src/types/domain.ts
@@ -14,6 +14,9 @@ export interface User {
   phoneVerified: boolean;
   signupType: SignupType;
   timezone: string;
+  addressPostalCode?: string;
+  addressLine1?: string;
+  addressLine2?: string;
   notificationSettings?: NotificationSettings;
   lastLoginAt?: string;
   withdrawnAt?: string;

--- a/front/src/utils/api.ts
+++ b/front/src/utils/api.ts
@@ -1,6 +1,19 @@
-import { API_BASE, STORAGE_KEYS } from './constants';
+import { API_BASE, STORAGE_KEYS, USER_AUTH_CHANGE_EVENT } from './constants';
 import type { ApiResponse } from '../types';
 import type { ExchangeRate } from '../types';
+
+export function notifyUserAuthChange(): void {
+  window.dispatchEvent(new Event(USER_AUTH_CHANGE_EVENT));
+}
+
+/** 일반 회원 로그인 세션 제거 (관리자와 동일 STORAGE_KEYS.TOKEN 사용 시 주의) */
+export function clearUserSession(): void {
+  localStorage.removeItem(STORAGE_KEYS.TOKEN);
+  localStorage.removeItem(STORAGE_KEYS.USER_ID);
+  localStorage.removeItem(STORAGE_KEYS.USER_EMAIL);
+  localStorage.removeItem(STORAGE_KEYS.USER_NICKNAME);
+  notifyUserAuthChange();
+}
 
 function getHeaders(): Record<string, string> {
   const headers: Record<string, string> = {

--- a/front/src/utils/constants.ts
+++ b/front/src/utils/constants.ts
@@ -7,4 +7,9 @@ export const STORAGE_KEYS = {
   TOKEN: 'ruxpress_token',
   LOCALE: 'ruxpress_locale',
   USER_ID: 'ruxpress_user_id',
+  USER_EMAIL: 'ruxpress_user_email',
+  USER_NICKNAME: 'ruxpress_user_nickname',
 } as const;
+
+/** UserLayout 등에서 로그인/로그아웃 후 헤더를 다시 그리기 위해 사용 */
+export const USER_AUTH_CHANGE_EVENT = 'ruxpress:user-auth-change';

--- a/front/tsconfig.json
+++ b/front/tsconfig.json
@@ -20,5 +20,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts"]
 }

--- a/sql/DDL.sql
+++ b/sql/DDL.sql
@@ -24,9 +24,9 @@ CREATE TABLE `user_devices` (
 
 CREATE TABLE `verifications` (
 	`id`	BIGINT	NOT NULL,
-	`type`	ENUM('EMAIL', 'PHONE')	NOT NULL	COMMENT '인증 유형',
+	`type`	ENUM('EMAIL', 'PHONE', 'PASSWORD_RESET')	NOT NULL	COMMENT '인증 유형',
 	`target`	VARCHAR(255)	NOT NULL	COMMENT '인증 대상 (이메일 또는 전화번호)',
-	`code`	VARCHAR(10)	NOT NULL	COMMENT '인증 코드 (6자리)',
+	`code`	VARCHAR(64)	NOT NULL	COMMENT '인증 코드 (6자리)',
 	`is_verified`	TINYINT(1)	NOT NULL	DEFAULT 0	COMMENT '인증 완료 여부',
 	`attempt_count`	INT	NOT NULL	DEFAULT 0	COMMENT '시도 횟수 (최대 5회)',
 	`expires_at`	DATETIME	NOT NULL	COMMENT '만료 시각',
@@ -97,7 +97,10 @@ CREATE TABLE `users` (
 	`withdrawn_at`	DATETIME	NULL	COMMENT '탈퇴 일시',
 	`created_at`	DATETIME	NOT NULL	DEFAULT CURRENT_TIMESTAMP	COMMENT '가입 일시',
 	`updated_at`	DATETIME	NOT NULL	DEFAULT CURRENT_TIMESTAMP,
-	`deleted_at`	DATETIME	NULL	COMMENT '소프트 삭제'
+	`deleted_at`	DATETIME	NULL	COMMENT '소프트 삭제',
+	`address_postal_code` VARCHAR(10) NULL COMMENT '우편번호',
+	`address_line1` VARCHAR(255) NULL COMMENT '기본 주소',
+	`address_line2` VARCHAR(255) NULL COMMENT '상세 주소'
 );
 
 CREATE TABLE `notices` (

--- a/sql/DDL.sql
+++ b/sql/DDL.sql
@@ -26,7 +26,7 @@ CREATE TABLE `verifications` (
 	`id`	BIGINT	NOT NULL,
 	`type`	ENUM('EMAIL', 'PHONE', 'PASSWORD_RESET')	NOT NULL	COMMENT '인증 유형',
 	`target`	VARCHAR(255)	NOT NULL	COMMENT '인증 대상 (이메일 또는 전화번호)',
-	`code`	VARCHAR(64)	NOT NULL	COMMENT '인증 코드 (6자리)',
+	`code`	VARCHAR(64)	NOT NULL	COMMENT '인증 코드 (6자리) 또는 재설정 토큰(비밀번호 재설정)',
 	`is_verified`	TINYINT(1)	NOT NULL	DEFAULT 0	COMMENT '인증 완료 여부',
 	`attempt_count`	INT	NOT NULL	DEFAULT 0	COMMENT '시도 횟수 (최대 5회)',
 	`expires_at`	DATETIME	NOT NULL	COMMENT '만료 시각',


### PR DESCRIPTION

# [feat] REQ-001 이메일 인증 후 회원가입, 로그인, 마이페이지 연동, 비밀번호 변경/찾기, 로그아웃

### 변경 사항
**Backend**
- 회원가입 시 주소(addressLine1/Line2/PostalCode) 입력 처리 추가
- 로그인 API (`POST /v1/users/login`) — JWT 발급 및 사용자 정보 반환
- 프로필 조회 API (`GET /v1/users/me`) — Bearer 토큰 기반 본인 정보 조회
- 비밀번호 변경 API (`POST /v1/users/me/password`) — 현재 비밀번호 확인 후 변경
- 비밀번호 찾기/재설정 API (`POST /password/forgot`, `/password/reset`) — 이메일 토큰 기반 재설정
- `PasswordResetService`, `EmailService` 신규 생성
- `JwtUtil`에 `resolveUserIdFromAuthorizationHeader` 추가
- 
**Frontend**
- 로그인 페이지 — localStorage에 사용자 정보 저장, 비밀번호 찾기 링크 추가
- 회원가입 페이지 — 주소 입력 필드 추가
- 마이페이지 — API 연동 프로필 조회 및 비밀번호 변경 UI
- 비밀번호 찾기/재설정 페이지 신규 (`ForgotPassword`, `ResetPassword`)
- 헤더 — 로그인 상태 분기 (닉네임 표시 / 로그인 버튼), 로그아웃 처리
- `routes.ts`에 `/forgot-password`, `/reset-password` 라우트 추가

### 테스트
- [x] 로컬에서 테스트 완료
- [x] 관련 기능 수동 테스트 완료

### 체크리스트
- [x] 컨벤션에 맞게 커밋/브랜치 이름 작성
- [x] 불필요한 로그/주석 제거
- [x] 문서(README/주석) 업데이트 필요 시 반영

### 관련 이슈/티켓
